### PR TITLE
"Unrecognized token [" created in the preprocess function

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -2357,7 +2357,7 @@
      * template tokens with content.
      */
     function preprocess(code) {
-      return interpolate(code, template).replace(/\$/g, /\d+/.exec(uid));
+      return interpolate(code, template).replace(/\$/g, /\d+/.exec(uid).join());
     }
 
     /*------------------------------------------------------------------------*/


### PR DESCRIPTION
Benchmark.js on Chromium is buggy because of the UID interpolation in the preprocess method.

`RegExp.exec` returns an array, so `/\d+/.exec("uid123")` returns `["123"]`.

When used with the `String.replace` function, it usually works fine, however on Chromium `("var r$ = 3").replace(/\$/g, ["123"])` results in `"var r[123] = 3"` which cannot be compiled and causes Benchmark.js to fail.
