### PR TITLE
Add a note about development build

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ Optionally, use the [microtime module](https://github.com/wadey/node-microtime) 
 npm install microtime
 ```
 
-Usage example:
+Alternatively, use the development build:
+
+```
+$ npm i --save bestiejs/benchmark.js
+```
+
+## Usage example
 
 ```js
 var suite = new Benchmark.Suite;


### PR DESCRIPTION
The last published version on NPM is [v1.0.0](/bestiejs/benchmark.js/releases/tag/v1.0.0) (which is quite old).
This PR adds a note about _How to use the current development build in your project_.