### PR TITLE
Load Lo-Dash from correct location

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,7 @@
 
   /** The `lodash` utility function. */
   var _ = root._ || (root._ = (
-    _ = load('../node_modules/lodash-compat/lodash.js') || root._,
+    _ = load('../node_modules/lodash-compat/index.js') || root._,
     _ = _._ || _,
     _.runInContext(root)
   ));


### PR DESCRIPTION
The test won't run of the master branch:
```
$  node test/test
module.js:338
    throw err;
          ^
Error: Cannot find module '../node_modules/qunitjs/qunit/qunit.js'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/home/simon/projects/benchmark.js/test/test.js:26:13)
    at Object.<anonymous> (/home/simon/projects/benchmark.js/test/test.js:1293:3)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```
It appears that the file name of Lo-Dash has been changed. This commit follows the change and makes the tests run fine.