### PR TITLE
Include nano.jar in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "requirejs": "~2.1.0"
   },
   "files": [
-    "benchmark.js"
+    "benchmark.js",
+    "nano.jar"
   ]
 }


### PR DESCRIPTION
[Twitter convo](https://twitter.com/jdalton/status/596742896495112192)

As is common, we launch our test suite to a grid, which tests against various browsers, FF, Chrome, etc. The node_module, npm publish'd version of this isn't currently including the `nano.jar` so we're currently relying on a copy-pasta version.

Cc/ @jdalton 