### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "benchmark.js",
-  "version": "2.0.0-pre",
   "main": "benchmark.js",
   "dependencies": {
     "lodash": "3.0.0",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property