### PR TITLE
Removed inlining of fn/setup/teardown inside a try/catch

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1607,11 +1607,11 @@
             // When `deferred.cycles` is `0` then...
             'if(!d#.cycles){' +
             // set `deferred.fn`,
-            'd#.fn=function(){var ${fnArg}=d#;if(typeof f#=="function"){try{${fn}\n}catch(e#){f#(d#)}}else{${fn}\n}};' +
+            'd#.fn=function(){var ${fnArg}=d#;if(typeof f#=="function"){f#(d#)}else{${fn}\n}};' +
             // set `deferred.teardown`,
-            'd#.teardown=function(){d#.cycles=0;if(typeof td#=="function"){try{${teardown}\n}catch(e#){td#()}}else{${teardown}\n}};' +
+            'd#.teardown=function(){d#.cycles=0;if(typeof td#=="function"){td#()}else{${teardown}\n}};' +
             // execute the benchmark's `setup`,
-            'if(typeof su#=="function"){try{${setup}\n}catch(e#){su#()}}else{${setup}\n};' +
+            'if(typeof su#=="function"){su#()}else{${setup}\n}' +
             // start timer,
             't#.start(d#);' +
             // and then execute `deferred.fn` and return a dummy object.


### PR DESCRIPTION
While getting accustomed to the code I noticed an oddity.

I'm unsure why, if it's checked as a function, fn/setup/teardown is then inlined and wrapped in a try/catch, with the catch then calling it as a function. When running the tests, I found no case where it seemed to be intentional. There may be a rare case it doesn't throw and works as expected (with different scoping rules), but I can't see a benefit to it.

Removing it makes it easier for someone to make the hooks async; possibly myself..as I'm experimenting, but no promises.

I traced the code back to the first introduction of this type of logic, here https://github.com/bestiejs/benchmark.js/commit/bb1511c1a53147d80da478b75728a18f4950f59f but it's still unclear to me why it's needed since if it's not a function, it would be inlined in the `else` clause. Certainly, please correct me if I'm wrong. The tests still pass, so I would argue there's some missing tests, if this behavior is needed. :beers: 
