### PR TITLE
Use instanceof instead of constructor

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -467,7 +467,7 @@
       var suite = this;
 
       // Allow instance creation without the `new` operator.
-      if (suite == null || suite.constructor != Suite) {
+      if (!(suite instanceof Suite)) {
         return new Suite(name, options);
       }
       // Juggle arguments.


### PR DESCRIPTION
This is handy when extending classes from the Suite class. The `constructor` points to the extended class while `instaceof` detects whether `Suite`  is anywhere in the prototype chain (the `Suite` instances or derived class instances).

/cc @izuzak After this is merged, we should bump the benchmark version and then https://github.com/izuzak/benchtable/pull/8 is ready to be merged. :smile: 