### PR TITLE
Fix Benchmark#toString() stringification of error

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1527,7 +1527,16 @@
           result = bench.name || (_.isNaN(id) ? id : '<Test #' + id + '>');
 
       if (error) {
-        result += ': ' + join(error);
+        var errorStr;
+        if (!_.isObject(error)) {
+          errorStr = String(error);
+        } else if (!(error instanceof Error)) {
+          errorStr = join(error);
+        } else {
+          errorStr = join(_.assign({name: error.name, message: error.message}, error));
+        }
+
+        result += ': ' + errorStr;
       } else {
         result += ' x ' + formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm +
           stats.rme.toFixed(2) + '% (' + size + ' run' + (size == 1 ? '' : 's') + ' sampled)';


### PR DESCRIPTION
`Benchmark#toString()` calls `join()` to convert its `error` property to a string.  Since the specified properties of `Error` (`message` and `name`) are not enumerable, when `error` is an instance of `Error` this produces a string which is either empty or contains only properties assigned to the error after instantiation.  This is often not particularly useful to the caller.  It appears that this has been the case since its introduction in ee59f95.

This PR attempts to achieve what I assume was the intended behavior by calling `join` on an object with the `name` and `message` properties of the error in addition to any enumerable properties.  If you would prefer a different behavior, let me know.

Thanks,
Kevin