### PR TITLE
Add fallback runScript insertion location

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -660,7 +660,9 @@
     function runScript(code) {
       var anchor = freeDefine ? define.amd : Benchmark,
           script = doc.createElement('script'),
-          sibling = doc.getElementsByTagName('script')[0],
+          sibling = doc.getElementsByTagName('script')[0] || 
+                    doc.body.children[doc.body.children.length - 1] || // Last Element Node in <body> OR
+                    doc.body.appendChild(doc.createElement('script')), // Create element to insert next to
           parent = sibling.parentNode,
           prop = uid + 'runScript',
           prefix = '(' + (freeDefine ? 'define.amd.' : 'Benchmark.') + prop + '||function(){})();';

--- a/benchmark.js
+++ b/benchmark.js
@@ -660,7 +660,7 @@
     function runScript(code) {
       var anchor = freeDefine ? define.amd : Benchmark,
           script = doc.createElement('script'),
-          sibling = doc.getElementsByTagName('script')[0] || 
+          sibling = doc.getElementsByTagName('script')[0] ||
                     doc.body.children[doc.body.children.length - 1] || // Last Element Node in <body> OR
                     doc.body.appendChild(doc.createElement('script')), // Create element to insert next to
           parent = sibling.parentNode,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "coveralls": "^2.11.9",
     "docdown": "~0.5.1",
-    "istanbul": "0.4.3",
+    "istanbul": "0.4.4",
     "qunit-extras": "^2.0.1",
     "qunitjs": "^2.0.0",
     "requirejs": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benchmark",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "A benchmarking library that supports high-resolution timers & returns statistically significant results.",
   "homepage": "https://benchmarkjs.com/",
   "license": "MIT",
@@ -14,19 +14,19 @@
   ],
   "repository": "bestiejs/benchmark.js",
   "scripts": {
-    "doc": "docdown benchmark.js doc/README.md style=github title=\"<a href=\\\"https://benchmarkjs.com/\\\">Benchmark.js</a> <span>v${npm_package_version}</span>\" toc=categories url=https://github.com/bestiejs/benchmark.js/blob/${npm_package_version}/benchmark.js",
+    "doc": "docdown benchmark.js doc/README.md toc='categories' url=\"https://github.com/bestiejs/benchmark.js/blob/${npm_package_version}/benchmark.js\" title=\"<a href=\\\"https://benchmarkjs.com/\\\">Benchmark.js</a> <span>v${npm_package_version}</span>\" hash='github'",
     "test": "node test/test"
   },
   "dependencies": {
-    "lodash": "^4.14.2",
+    "lodash": "^4.13.1",
     "platform": "^1.3.1"
   },
   "devDependencies": {
-    "coveralls": "^2.11.12",
-    "docdown": "~0.7.1",
-    "istanbul": "0.4.4",
-    "qunit-extras": "^2.1.0",
-    "qunitjs": "^2.0.1",
+    "coveralls": "^2.11.9",
+    "docdown": "~0.5.1",
+    "istanbul": "0.4.3",
+    "qunit-extras": "^2.0.0",
+    "qunitjs": "~1.23.1",
     "requirejs": "^2.2.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "coveralls": "^2.11.9",
     "docdown": "~0.5.1",
     "istanbul": "0.4.3",
-    "qunit-extras": "^2.0.0",
-    "qunitjs": "~1.23.1",
+    "qunit-extras": "^2.0.1",
+    "qunitjs": "^2.0.0",
     "requirejs": "^2.2.0"
   },
   "files": [


### PR DESCRIPTION
There's an issue wherein having no script tags on the page (but having the
js in memory executing) causes errors since runScript has no reference
point to inject scripts.

This commit allows for two cases:

1) If there are no script tags on the page, it will grab the last element
node in the body and insert scripts next to that element.

2) If there are no script tags on the page and the body element is EMPTY,
a script tag will be created and appended to body. Subsequent calls to
runScript will allow the first use case of inserting next to scripts to be
called.

This still passes the tests, and I was able to verify the creation of a new `script` tag after stepping through my debugger and deleting the contents of `document.body`.

If there's anything I can do to make this better/more acceptable, please let me know! The tests seem sort of nebulous to me at this point? only because I guess there isn't a test suite for `runScript` ! hahaha. 

**P.S.** My commit that says 'convert to tabs' is actually supposed to be 'convert to spaces'. Oops. 
