### PR TITLE
example/jsperf/index.html: fix lodash location

### DIFF
--- a/example/jsperf/index.html
+++ b/example/jsperf/index.html
@@ -231,7 +231,7 @@
       &middot; by <a href="https://mathiasbynens.be/" title="Mathias Bynens, front-end web developer">@mathias</a>
     </footer>
 
-    <script src="../../node_modules/lodash/lodash.min.js"></script>
+    <script src="../../node_modules/lodash/lodash.js"></script>
     <script src="../../node_modules/platform/platform.js"></script>
     <script src="../../benchmark.js"></script>
     <script src="ui.js"></script>

--- a/example/jsperf/index.html
+++ b/example/jsperf/index.html
@@ -231,7 +231,7 @@
       &middot; by <a href="https://mathiasbynens.be/" title="Mathias Bynens, front-end web developer">@mathias</a>
     </footer>
 
-    <script src="../../node_modules/lodash/index.js"></script>
+    <script src="../../node_modules/lodash/lodash.min.js"></script>
     <script src="../../node_modules/platform/platform.js"></script>
     <script src="../../benchmark.js"></script>
     <script src="ui.js"></script>


### PR DESCRIPTION
lodash/index.js won't work in a browser, use lodash/lodash.min.js

BTW this example how to use benchmark.js in a browser is a useful thing,
having also simpler examples/templates could also be helpful.