### PR TITLE
Make browserscope use https so that it'll work where-ever you're loading from...

### DIFF
--- a/example/jsperf/main.css
+++ b/example/jsperf/main.css
@@ -345,7 +345,7 @@ footer {
   width: 232px;
   height: 39px;
   filter: none;
-  background: url(//www.browserscope.org/static/img/logo.png) 0 0 no-repeat;
+  background: url(https://www.browserscope.org/static/img/logo.png) 0 0 no-repeat;
 }
 
 #bs-ua {

--- a/plugin/ui.browserscope.js
+++ b/plugin/ui.browserscope.js
@@ -578,7 +578,7 @@
       setMessage(me.texts.loading);
       // request Browserscope chart data and pass it to `google.visualization.Query.setResponse()`
       (new visualization.Query(
-        '//www.browserscope.org/gviz_table_data?category=usertest_' + me.key + '&v=' + filterMap[filterBy],
+        'https://www.browserscope.org/gviz_table_data?category=usertest_' + me.key + '&v=' + filterMap[filterBy],
         { 'sendMethod': 'scriptInjection' }
       ))
       .send(onComplete);


### PR DESCRIPTION
... whether /example/jsperf/ is loaded via file://, http:// or https://, it shouldn't matter.