### PR TITLE
/example/jsperf/ update/augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ suite.add('RegExp#test', function() {
 // => Fastest is String#indexOf
 ```
 
+## Developing
+
+The following `npm` tasks are available to assist during development and release:
+
+- `npm run server` will start `live-server` and open the base directory in your browser; then you can, for example, browse to /example/jsperf/ to run the available tests in your browser using the local benchmark.js file. 
+
+- `npm run test` -- nuff said.
+
+- `npm run doc` -- will regenerate the documentation from source.
+
+Also note that rough support for a test *catalog* is available for the `/example/jsperf/` demo: run `./build-jsperf.sh` to update the catalog file and then the next reload of the `/example/jsperf/index.html` page will show a clickable list of all available tests near the bottom so you can browse and jump from one test file/suite to another.
+
+
 ## Support
 
 Tested in Chrome 46-47, Firefox 42-43, IE 9-11, Edge 13, Safari 8-9, Node.js 0.10-6, & PhantomJS 1.9.8.

--- a/build-jsperf.sh
+++ b/build-jsperf.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+#
+
+pushd .
+cd $( dirname "$0" )
+cd example/jsperf
+
+ls *.json5 > test-catalog.txt
+
+#    npm run server
+#
+# would start the live-server and when you browse to /example/jsperf/ then every test page
+# should list the entire set of available tests at the bottom of the page.
+#
+
+popd

--- a/example/jsperf/fpcvt-alt1.js
+++ b/example/jsperf/fpcvt-alt1.js
@@ -1,0 +1,303 @@
+
+
+/*
+Performance Test of encode_fp_value() vs. vanilla JS:
+
+Test                                    Ops/sec
+
+Classic : toString                      17,729
+                                        ±2.01%
+                                        17% slower
+
+Classic : add to string (= '' + val)    21,278
+                                        ±1.93%
+                                        fastest
+
+Classic :: toPrecision(max)             1,763
+                                        ±0.22%
+                                        92% slower
+
+Custom :: v1                            2,191
+                                        ±1.14%
+                                        90% slower
+
+Custom :: v2                            (bit faster than v1)
+
+Note: when you take out the sanity checks `if (...) throw new Error(...)` then you gain about 10%:
+2367 ops/sec -> 2657 ops/sec in another test run.
+
+Note: there's a *huge* difference in performance, both relative and absolute, for these buggers in MSIE, FF and Chrome!
+(The 'classic' code wins by a factor of about 2 in Chrome, but amazingly enough our custom encoder wins in FF and is on par in MSIE.
+
+At least that's what the initial set of test runs seems to indicate...
+*/
+
+
+function encode_fp_value2(flt) {
+  // sample JS code to encode a IEEE754 floating point value in a Unicode string.
+  //
+  // With provision to detect and store +0/-0 and +/-Inf and NaN
+  //
+  //
+  // Post Scriptum: encoding a fp number like this takes 1-5 Unicode characters
+  // (if we also encode mantissa length in the power character) so it MIGHT
+  // be better to provide a separate encoding for when the fp value can be printed
+  // in less bytes -- and then then there are the integers and decimal fractions
+  // used often by humans: multiply by 1K or 1M and you get another series of
+  // integers, most of the time!
+  // modulo: we can use 0x8000 or any lower power of 2 to prevent producing illegal Unicode
+  // sequences (the extra Unicode pages are triggered by a set of codes in the upper range
+  // which we cannot create this way, so no unicode verifiers will ever catch us for being
+  // illegal now!)
+  //
+  // WARNING: the exponent is not exactly 12 bits when you look at the Math.log2()
+  //          output, as there are these near-zero values to consider up to exponent
+  //          -1074 (-1074 + 52 = -1022 ;-) ) a.k.a. "denormalized zeroes":
+  //
+  //              Math.log2(Math.pow(2,-1074)) === -1074
+  //              Math.log2(Math.pow(2,-1075)) === -Infinity
+  //
+  //              Math.pow(2,1023) * Math.pow(2,-1073) === 8.881784197001252e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1074) === 4.440892098500626e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1075) === 0
+  //              Math.pow(2,1023) * Math.pow(2,-1076) === 0
+  //
+
+  // encode sign in bit 12
+  var s;
+  if (flt < 0) {
+    s = 4096;
+    flt = -flt;
+  } else {
+    s = 0;
+  }
+
+  // extract power from fp value    (WARNING: MSIE does not support log2(), see MDN!)
+  var exp2 = Math.log2(flt);
+  var p = exp2 | 0;  // --> +1023..-1024, pardon!, -1074 (!!!)
+  switch (p) {
+  // The power 0 also shows up when we treat a NaN or +/-Inf or +/-0:
+  case 0:
+    if (!flt) {
+      // +0, -0 or NaN:
+      if (isNaN(flt)) {
+        return String.fromCharCode(FPC_ENC_NAN);
+      } else {
+        // detect negative zero:
+        var is_negzero = Math.atan2(0, flt);  // +0 --> 0, -0 --> PI
+        if (is_negzero) {
+          return String.fromCharCode(FPC_ENC_NEGATIVE_ZERO);
+        } else {
+          return String.fromCharCode(FPC_ENC_POSITIVE_ZERO);
+        }
+      }
+    } else if (!isFinite(flt)) {
+      // -Inf / +Inf
+      if (flt > 0) {
+        return String.fromCharCode(FPC_ENC_POSITIVE_INFINITY);
+      } else {
+        return String.fromCharCode(FPC_ENC_NEGATIVE_INFINITY);
+      }
+    }
+    // fall through!
+
+  // The range <1e7..1e-3] can be encoded as short float when the value matches a few conditions:
+  case -3:
+  case -2:
+  case -1:
+  //case 0:
+  case 1:
+  case 2:
+  case 3:
+  case 4:
+  case 5:
+  case 6:
+    // if (!isFinite(flt)) {
+    //   throw new Error('fp encoding: internal failure in short float: not a finite number');
+    // }
+
+    // Note:
+    // We encode a certain range and type of values specially as that will deliver shorter Unicode
+    // sequences: 'human' values like `4200` and `0.125` (1/8th) are almost always
+    // not encoded *exactly* in IEE754 floats due to their base(2) storage nature.
+    //
+    // Here we detect quickly if the mantissa would span at most 3 decimal digits
+    // and the exponent happens to be within reasonable range: when this is the
+    // case, we encode them as a *decimal short float* in 13 bits, which happen
+    // to fit snugly in the unicode word range 0x8000..0xC000 or in a larger
+    // *decimal float* which spans two words: 13+15 bits.
+    var dp = (exp2 * FPC_ENC_LOG2_TO_LOG10 + 1) | 0;
+    var dy = flt / Math.pow(10, dp - 3);    // take mantissa (which is guaranteed to be in range [0.999 .. 0]) and multiply by 1000
+    //console.log('decimal float test:', flt, exp2, exp2 * FPC_ENC_LOG2_TO_LOG10, p, dp, dy);
+
+    // fist check exponent, only when in range perform the costly modulo operation
+    // and comparison to further check conditions suitable for short float encoding.
+    //
+    // `dy < 1024` is not required, theoretically, but here as a precaution:
+    if (dp >= -2 && dp <= 7 /* && dy < 1024 */) {
+      var chk = dy % 1;
+      //console.log('decimal float eligible? A:', flt, dy, chk, dp);
+      if (chk === 0) {                     // alt check:   `(dy | 0) === dy`
+        // this input value is potentially eligible for 'short decimal float encoding'...
+        //
+        // *short* decimal floats take 13-14 bits (10+~4) at 0x8000..0xCFFF as
+        // short floats have exponent -3..+5 in $1000 0sxx .. $1100 1sxx:
+        // --> 0x10..0x19 minus 0x10 --> [0x00..0x09] --> 10(!) exponent values.
+        //
+        // As we want to be able to store 'millions' (1E6) like that, our positive
+        // range should reach +6, which leaves -3 (don't forget about the 0!);
+        // we also want to support *milli* values (exponent = -3) which is
+        // just feasible with this range.
+        dp += 2;
+
+        // short float eligible value for sure!
+        var dc;
+
+        //
+        // Bits in word:
+        // - 0..9: integer mantissa; values 0..1023
+        // - 10: sign
+        // - 11..14: exponent 0..9 with offset -3 --> -3..+6
+        // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+        //       so we can only set this bit and have particular values in bits 0..14 at the same time
+        //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+        //
+        // alt:                    __(!!s << 10)_   _dy_____
+        dc = 0x8000 + (dp << 11) + (s ? 1024 : 0) + (dy | 0);                  // the `| 0` shouldn't be necessary but is there as a precaution
+        //console.log('d10-dbg', dp, dy, s, '0x' + dc.toString(16), flt);
+        return String.fromCharCode(dc);
+      }
+    }
+    // fall through!
+
+  // this range of exponents shows up when you handle denormalized zeroes:
+  case -1074:
+  case -1073:
+  case -1072:
+  case -1071:
+  case -1070:
+  case -1069:
+  case -1068:
+  case -1067:
+  case -1066:
+  case -1065:
+  case -1064:
+  case -1063:
+  case -1062:
+  case -1061:
+  case -1060:
+  case -1059:
+  case -1058:
+  case -1057:
+  case -1056:
+  case -1055:
+  case -1054:
+  case -1053:
+  case -1052:
+  case -1051:
+  case -1050:
+  case -1049:
+  case -1048:
+  case -1047:
+  case -1046:
+  case -1045:
+  case -1044:
+  case -1043:
+  case -1042:
+  case -1041:
+  case -1040:
+  case -1039:
+  case -1038:
+  case -1037:
+  case -1036:
+  case -1035:
+  case -1034:
+  case -1033:
+  case -1032:
+  case -1031:
+  case -1030:
+  case -1029:
+  case -1028:
+  case -1027:
+  case -1026:
+  case -1025:
+    if (p < -1024) {
+      // Correct for our process: we actually want the bits in the IEE754 exponent, hence
+      // exponents lower than -1024, a.k.a. *denormalized zeroes*, are treated exactly
+      // like that in our code as well: we will produce leading mantissa ZERO words then.
+      p = -1024;
+    }
+    // fall through
+
+  default:
+    // and produce the mantissa so that it's range now is [0..2>: for powers > 0
+    // the value y will be >= 1 while for negative powers, i.e. tiny numbers, the
+    // value 0 < y < 1.
+    var y = flt / Math.pow(2, p);
+    y /= 2;                       // we do this in two steps to allow handling even the largest floating point values, which have p=1023: Math.pow(2, p+1) would fail for those!
+    // if (y >= 1) {
+    //   throw new Error('fp float encoding: mantissa above allowed max');
+    // }
+
+    var a = '';
+    var b = y;       // alt: y - 1, but that only gives numbers 0 < b < 1 for p > 0
+    // if (b < 0) {
+    //   throw new Error('fp encoding: negative mantissa');
+    // }
+    // if (b === 0) {
+    //   throw new Error('fp encoding: ZERO mantissa');
+    // }
+
+    // and show the unicode character codes for debugging/diagnostics:
+    //var dbg = [0 /* Note: this slot will be *correctly* filled at the end */];
+    //console.log('dbg @ start', 0, p + 1024 + s, flt, dbg, s, p, y, b);
+
+    for (var i = 0; b && i < FPC_ENC_MAXLEN; i++) {
+      b *= FPC_ENC_MODULO;
+      var c = b | 0;                  // grab the integer part
+      var d = b - c;
+
+      //dbg[i + 1] = c;
+      //console.log('dbg @ step', i, c, flt, dbg, s, p, y, b, d, '0x' + c.toString(16));
+
+      a += String.fromCharCode(c);
+      b = d;
+    }
+
+    // encode sign + power + mantissa length in a Unicode char
+    // (i E {0..4} as maximum size FPC_ENC_MAXLEN=4 ==> 3 bits of length @ bits 13.14.15 in word)
+    //
+    // Bits in word:
+    // - 0..11: exponent; values -1024..+1023 with an offset of 1024 to make them all positive numbers
+    // - 12: sign
+    // - 13,14: length 1..4: the number of words following to define the mantissa
+    // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+    //       so we can only set this bit and have particular values in bits 0..14 at the same time
+    //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+    //
+    // Special values (with bit 15 set):
+    // - +Inf
+    // - -Inf
+    // - NaN
+    // - -0    (negative zero)
+    // - +0    (positive zero)
+    //
+    --i;
+    // if (i > 3) {
+    //   throw new Error('fp encode length too large');
+    // }
+    var h = p + 1024 + s + (i << 13 /* i * 8192 */ );   // brackets needed as + comes before <<   :-(
+    a = String.fromCharCode(h) + a;
+    //dbg[0] = h;
+    //console.log('dbg @ end', i, h, flt, dbg, s, p, y, b, '0x' + h.toString(16));
+    return a;
+  }
+}
+
+
+
+
+
+
+console.info('fpcvt-alt1 loaded');
+

--- a/example/jsperf/fpcvt-alt2.js
+++ b/example/jsperf/fpcvt-alt2.js
@@ -1,0 +1,212 @@
+
+
+
+
+/*
+Performance Test of encode_fp_value() vs. vanilla JS:
+
+Test                                    Ops/sec
+
+Classic : toString                      17,729
+                                        ±2.01%
+                                        17% slower
+
+Classic : add to string (= '' + val)    21,278
+                                        ±1.93%
+                                        fastest
+
+Classic :: toPrecision(max)             1,763
+                                        ±0.22%
+                                        92% slower
+
+Custom :: v1                            2,191
+                                        ±1.14%
+                                        90% slower
+*/
+
+
+function encode_fp_value3(flt) {
+  // sample JS code to encode a IEEE754 floating point value in a Unicode string.
+  //
+  // With provision to detect and store +0/-0 and +/-Inf and NaN
+  //
+  //
+  // Post Scriptum: encoding a fp number like this takes 1-5 Unicode characters
+  // (if we also encode mantissa length in the power character) so it MIGHT
+  // be better to provide a separate encoding for when the fp value can be printed
+  // in less bytes -- and then then there are the integers and decimal fractions
+  // used often by humans: multiply by 1K or 1M and you get another series of
+  // integers, most of the time!
+  // modulo: we can use 0x8000 or any lower power of 2 to prevent producing illegal Unicode
+  // sequences (the extra Unicode pages are triggered by a set of codes in the upper range
+  // which we cannot create this way, so no unicode verifiers will ever catch us for being
+  // illegal now!)
+  //
+  // WARNING: the exponent is not exactly 12 bits when you look at the Math.log2()
+  //          output, as there are these near-zero values to consider up to exponent
+  //          -1074 (-1074 + 52 = -1022 ;-) ) a.k.a. "denormalized zeroes":
+  //
+  //              Math.log2(Math.pow(2,-1074)) === -1074
+  //              Math.log2(Math.pow(2,-1075)) === -Infinity
+  //
+  //              Math.pow(2,1023) * Math.pow(2,-1073) === 8.881784197001252e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1074) === 4.440892098500626e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1075) === 0
+  //              Math.pow(2,1023) * Math.pow(2,-1076) === 0
+  //
+
+  if (!flt) {
+    // +0, -0 or NaN:
+    if (isNaN(flt)) {
+      return String.fromCharCode(FPC_ENC_NAN);
+    } else {
+      // detect negative zero:
+      var is_negzero = Math.atan2(0, flt);  // +0 --> 0, -0 --> PI
+      if (is_negzero) {
+        return String.fromCharCode(FPC_ENC_NEGATIVE_ZERO);
+      } else {
+        return String.fromCharCode(FPC_ENC_POSITIVE_ZERO);
+      }
+    }
+  } else if (isFinite(flt)) {
+    // encode sign in bit 12
+    var s;
+    if (flt < 0) {
+      s = 4096;
+      flt = -flt;
+    } else {
+      s = 0;
+    }
+
+    // extract power from fp value    (WARNING: MSIE does not support log2(), see MDN!)
+    var exp2 = Math.log2(flt);
+    var p = exp2 | 0;  // --> +1023..-1024, pardon!, -1074 (!!!)
+    if (p < -1024) {
+      // Correct for our process: we actually want the bits in the IEE754 exponent, hence
+      // exponents lower than -1024, a.k.a. *denormalized zeroes*, are treated exactly
+      // like that in our code as well: we will produce leading mantissa ZERO words then.
+      p = -1024;
+    } else {
+      // Note:
+      // We encode a certain range and type of values specially as that will deliver shorter Unicode
+      // sequences: 'human' values like `4200` and `0.125` (1/8th) are almost always
+      // not encoded *exactly* in IEE754 floats due to their base(2) storage nature.
+      //
+      // Here we detect quickly if the mantissa would span at most 3 decimal digits
+      // and the exponent happens to be within reasonable range: when this is the
+      // case, we encode them as a *decimal short float* in 13 bits, which happen
+      // to fit snugly in the unicode word range 0x8000..0xC000 or in a larger
+      // *decimal float* which spans two words: 13+15 bits.
+      var dp = (exp2 * FPC_ENC_LOG2_TO_LOG10 + 1) | 0;
+      var dy = flt / Math.pow(10, dp - 3);    // take mantissa (which is guaranteed to be in range [0.999 .. 0]) and multiply by 1000
+      //console.log('decimal float test:', flt, exp2, exp2 * FPC_ENC_LOG2_TO_LOG10, p, dp, dy);
+
+      // fist check exponent, only when in range perform the costly modulo operation
+      // and comparison to further check conditions suitable for short float encoding.
+      //
+      // `dy < 1024` is not required, theoretically, but here as a precaution:
+      if (dp >= -2 && dp <= 7 /* && dy < 1024 */) {
+        var chk = dy % 1;
+        //console.log('decimal float eligible? A:', flt, dy, chk, dp);
+        if (chk === 0) {                     // alt check:   `(dy | 0) === dy`
+          // this input value is potentially eligible for 'short decimal float encoding'...
+          //
+          // *short* decimal floats take 13-14 bits (10+~4) at 0x8000..0xCFFF as
+          // short floats have exponent -3..+5 in $1000 0sxx .. $1100 1sxx:
+          // --> 0x10..0x19 minus 0x10 --> [0x00..0x09] --> 10(!) exponent values.
+          //
+          // As we want to be able to store 'millions' (1E6) like that, our positive
+          // range should reach +6, which leaves -3 (don't forget about the 0!);
+          // we also want to support *milli* values (exponent = -3) which is
+          // just feasible with this range.
+          dp += 2;
+
+          // short float eligible value for sure!
+          var dc;
+
+          //
+          // Bits in word:
+          // - 0..9: integer mantissa; values 0..1023
+          // - 10: sign
+          // - 11..14: exponent 0..9 with offset -3 --> -3..+6
+          // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+          //       so we can only set this bit and have particular values in bits 0..14 at the same time
+          //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+          //
+          // alt:                    __(!!s << 10)_   _dy_____
+          dc = 0x8000 + (dp << 11) + (s ? 1024 : 0) + (dy | 0);                  // the `| 0` shouldn't be necessary but is there as a precaution
+          //console.log('d10-dbg', dp, dy, s, '0x' + dc.toString(16), flt);
+          return String.fromCharCode(dc);
+        }
+      }
+    }
+
+    // and produce the mantissa so that it's range now is [0..2>: for powers > 0
+    // the value y will be >= 1 while for negative powers, i.e. tiny numbers, the
+    // value 0 < y < 1.
+    var y = flt / Math.pow(2, p);
+    y /= 2;
+
+    var a = '';
+    var b = y;       // alt: y - 1, but that only gives numbers 0 < b < 1 for p > 0
+
+    // and show the unicode character codes for debugging/diagnostics:
+    //var dbg = [0 /* Note: this slot will be *correctly* filled at the end */];
+    //console.log('dbg @ start', 0, p + 1024 + s, flt, dbg, s, p, y, b);
+
+    for (var i = 0; b && i < FPC_ENC_MAXLEN; i++) {
+      b *= FPC_ENC_MODULO;
+      var c = b | 0;                  // grab the integer part
+      var d = b - c;
+
+      //dbg[i + 1] = c;
+      //console.log('dbg @ step', i, c, flt, dbg, s, p, y, b, d, '0x' + c.toString(16));
+
+      a += String.fromCharCode(c);
+      b = d;
+    }
+
+    // encode sign + power + mantissa length in a Unicode char
+    // (i E {0..4} as maximum size FPC_ENC_MAXLEN=4 ==> 3 bits of length @ bits 13.14.15 in word)
+    //
+    // Bits in word:
+    // - 0..11: exponent; values -1024..+1023 with an offset of 1024 to make them all positive numbers
+    // - 12: sign
+    // - 13,14: length 1..4: the number of words following to define the mantissa
+    // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+    //       so we can only set this bit and have particular values in bits 0..14 at the same time
+    //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+    //
+    // Special values (with bit 15 set):
+    // - +Inf
+    // - -Inf
+    // - NaN
+    // - -0    (negative zero)
+    // - +0    (positive zero)
+    //
+    --i;
+
+    var h = p + 1024 + s + (i << 13 /* i * 8192 */ );   // brackets needed as + comes before <<   :-(
+    a = String.fromCharCode(h) + a;
+    //dbg[0] = h;
+    //console.log('dbg @ end', i, h, flt, dbg, s, p, y, b, '0x' + h.toString(16));
+    return a;
+  } else {
+    // -Inf / +Inf
+    if (flt > 0) {
+      return String.fromCharCode(FPC_ENC_POSITIVE_INFINITY);
+    } else {
+      return String.fromCharCode(FPC_ENC_NEGATIVE_INFINITY);
+    }
+  }
+}
+
+
+
+
+
+
+
+
+console.info('fpcvt-alt2 loaded');
+

--- a/example/jsperf/fpcvt.js
+++ b/example/jsperf/fpcvt.js
@@ -1,0 +1,452 @@
+
+
+
+
+// See also:
+//
+//   - https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+//     + https://ece.uwaterloo.ca/~dwharder/NumericalAnalysis/02Numerics/Double/paper.pdf
+//     + http://perso.ens-lyon.fr/jean-michel.muller/goldberg.pdf
+//   - http://steve.hollasch.net/cgindex/coding/ieeefloat.html
+//   - https://en.wikipedia.org/wiki/IEEE_floating_point
+//   - https://www.cs.umd.edu/class/sum2003/cmsc311/Notes/Data/float.html
+//   - https://www.doc.ic.ac.uk/~eedwards/compsys/float/
+//
+
+
+
+
+// The modulo 0x8000 takes 4 characters for a mantissa of 52 bits, while the same goes
+// for modulo 0x4000.
+// So we either have the upper bit at mask 0x4000 available on every char or we have
+// some spare bits in the last word...
+const FPC_ENC_MODULO = 0x8000;
+const FPC_ENC_MAXLEN = (function () {
+  var l = Math.log(Math.pow(2, 53)) / Math.log(FPC_ENC_MODULO);   // number of chars = words required to store worst case fp values
+  l += 1;
+  l |= 0;
+  //
+  // and since we want to see how easy it is to have run-away output for some fp numbers,
+  // we enlarge the boundary criterium for debugging/diagnostics:
+  //l *= 4  // just to detect nasty edge cases: will produce very long strings
+  return l;
+})();
+const FPC_ENC_LOG2_TO_LOG10 = 1 / Math.log2(10);
+
+// mask: 0x000F; offset: 0xF000:
+const FPC_ENC_POSITIVE_ZERO     = 0xF000;
+const FPC_ENC_NEGATIVE_ZERO     = 0xF001;
+const FPC_ENC_POSITIVE_INFINITY = 0xF002;
+const FPC_ENC_NEGATIVE_INFINITY = 0xF003;
+const FPC_ENC_NAN               = 0xF004;
+
+const FPC_DEC_POSITIVE_ZERO     = 0;
+const FPC_DEC_NEGATIVE_ZERO     = -0;
+const FPC_DEC_POSITIVE_INFINITY = Infinity;
+const FPC_DEC_NEGATIVE_INFINITY = -Infinity;
+const FPC_DEC_NAN               = NaN;
+
+
+
+
+
+
+/*
+Performance Test of encode_fp_value() vs. vanilla JS:
+
+Test                                    Ops/sec
+
+Classic : toString                      17,729
+                                        ±2.01%
+                                        17% slower
+
+Classic : add to string (= '' + val)    21,278
+                                        ±1.93%
+                                        fastest
+
+Classic :: toPrecision(max)             1,763
+                                        ±0.22%
+                                        92% slower
+
+Custom :: v1                            2,191
+                                        ±1.14%
+                                        90% slower
+*/
+
+
+function encode_fp_value(flt) {
+  // sample JS code to encode a IEEE754 floating point value in a Unicode string.
+  //
+  // With provision to detect and store +0/-0 and +/-Inf and NaN
+  //
+  //
+  // Post Scriptum: encoding a fp number like this takes 1-5 Unicode characters
+  // (if we also encode mantissa length in the power character) so it MIGHT
+  // be better to provide a separate encoding for when the fp value can be printed
+  // in less bytes -- and then then there are the integers and decimal fractions
+  // used often by humans: multiply by 1K or 1M and you get another series of
+  // integers, most of the time!
+  // modulo: we can use 0x8000 or any lower power of 2 to prevent producing illegal Unicode
+  // sequences (the extra Unicode pages are triggered by a set of codes in the upper range
+  // which we cannot create this way, so no unicode verifiers will ever catch us for being
+  // illegal now!)
+  //
+  // WARNING: the exponent is not exactly 12 bits when you look at the Math.log2()
+  //          output, as there are these near-zero values to consider up to exponent
+  //          -1074 (-1074 + 52 = -1022 ;-) ) a.k.a. "denormalized zeroes":
+  //
+  //              Math.log2(Math.pow(2,-1074)) === -1074
+  //              Math.log2(Math.pow(2,-1075)) === -Infinity
+  //
+  //              Math.pow(2,1023) * Math.pow(2,-1073) === 8.881784197001252e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1074) === 4.440892098500626e-16
+  //              Math.pow(2,1023) * Math.pow(2,-1075) === 0
+  //              Math.pow(2,1023) * Math.pow(2,-1076) === 0
+  //
+
+  if (!flt) {
+    // +0, -0 or NaN:
+    if (isNaN(flt)) {
+      return String.fromCharCode(FPC_ENC_NAN);
+    } else {
+      // detect negative zero:
+      var is_negzero = Math.atan2(0, flt);  // +0 --> 0, -0 --> PI
+      if (is_negzero) {
+        return String.fromCharCode(FPC_ENC_NEGATIVE_ZERO);
+      } else {
+        return String.fromCharCode(FPC_ENC_POSITIVE_ZERO);
+      }
+    }
+  } else if (isFinite(flt)) {
+    // encode sign in bit 12
+    var s;
+    if (flt < 0) {
+      s = 4096;
+      flt = -flt;
+    } else {
+      s = 0;
+    }
+
+    // extract power from fp value    (WARNING: MSIE does not support log2(), see MDN!)
+    var exp2 = Math.log2(flt);
+    var p = exp2 | 0;  // --> +1023..-1024, pardon!, -1074 (!!!)
+    if (p < -1024) {
+      // Correct for our process: we actually want the bits in the IEE754 exponent, hence
+      // exponents lower than -1024, a.k.a. *denormalized zeroes*, are treated exactly
+      // like that in our code as well: we will produce leading mantissa ZERO words then.
+      p = -1024;
+    } else {
+      // Note:
+      // We encode a certain range and type of values specially as that will deliver shorter Unicode
+      // sequences: 'human' values like `4200` and `0.125` (1/8th) are almost always
+      // not encoded *exactly* in IEE754 floats due to their base(2) storage nature.
+      //
+      // Here we detect quickly if the mantissa would span at most 3 decimal digits
+      // and the exponent happens to be within reasonable range: when this is the
+      // case, we encode them as a *decimal short float* in 13 bits, which happen
+      // to fit snugly in the unicode word range 0x8000..0xC000 or in a larger
+      // *decimal float* which spans two words: 13+15 bits.
+      var dp = (exp2 * FPC_ENC_LOG2_TO_LOG10 + 1) | 0;
+      var dy = flt / Math.pow(10, dp - 3);    // take mantissa (which is guaranteed to be in range [0.999 .. 0]) and multiply by 1000
+      //console.log('decimal float test:', flt, exp2, exp2 * FPC_ENC_LOG2_TO_LOG10, p, dp, dy);
+      if (dy < 0) {
+        throw new Error('fp decimal short float encoding: negative mantissa');
+      }
+      if (dy === 0) {
+        throw new Error('fp decimal short float encoding: ZERO mantissa');
+      }
+      if (dy > 1000) {
+        throw new Error('fp decimal short float encoding: 3 digits check');
+      }
+      var chk = dy % 1;
+      //console.log('decimal float eligible? A:', flt, dy, chk, dp);
+      if (chk === 0) {                     // alt check:   `(dy | 0) === dy`
+        // this input value is potentially eligible for 'short decimal float encoding'...
+        //
+        // *short* decimal floats take 13-14 bits (10+~4) at 0x8000..0xCFFF as
+        // short floats have exponent -3..+5 in $1000 0sxx .. $1100 1sxx:
+        // --> 0x10..0x19 minus 0x10 --> [0x00..0x09] --> 10(!) exponent values.
+        //
+        // As we want to be able to store 'millions' (1E6) like that, our positive
+        // range should reach +6, which leaves -3 (don't forget about the 0!);
+        // we also want to support *milli* values (exponent = -3) which is
+        // just feasible with this range.
+        dp += 2;
+        // `dy < 1024` is not required, theoretically, but here as a precaution:
+        if (dp >= 0 && dp <= 0x09 /* && dy < 1024 */) {
+          // short float eligible value for sure!
+          var dc;
+
+          //
+          // Bits in word:
+          // - 0..9: integer mantissa; values 0..1023
+          // - 10: sign
+          // - 11..14: exponent 0..9 with offset -3 --> -3..+6
+          // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+          //       so we can only set this bit and have particular values in bits 0..14 at the same time
+          //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+          //
+          // alt:                    __(!!s << 10)_   _dy_____
+          dc = 0x8000 + (dp << 11) + (s ? 1024 : 0) + (dy | 0);                  // the `| 0` shouldn't be necessary but is there as a precaution
+          //console.log('d10-dbg', dp, dy, s, '0x' + dc.toString(16), flt);
+          return String.fromCharCode(dc);
+        }
+      }
+    }
+
+    // and produce the mantissa so that it's range now is [0..2>: for powers > 0
+    // the value y will be >= 1 while for negative powers, i.e. tiny numbers, the
+    // value 0 < y < 1.
+    var y = flt / Math.pow(2, p);
+    y /= 2;
+    if (y >= 1) {
+      throw new Error('fp float encoding: mantissa above allowed max');
+    }
+
+    var a = '';
+    var b = y;       // alt: y - 1, but that only gives numbers 0 < b < 1 for p > 0
+    if (b < 0) {
+      throw new Error('fp encoding: negative mantissa');
+    }
+    if (b === 0) {
+      throw new Error('fp encoding: ZERO mantissa');
+    }
+
+    // and show the unicode character codes for debugging/diagnostics:
+    //var dbg = [0 /* Note: this slot will be *correctly* filled at the end */];
+    //console.log('dbg @ start', 0, p + 1024 + s, flt, dbg, s, p, y, b);
+
+    for (var i = 0; b && i < FPC_ENC_MAXLEN; i++) {
+      b *= FPC_ENC_MODULO;
+      var c = b | 0;                  // grab the integer part
+      var d = b - c;
+
+      //dbg[i + 1] = c;
+      //console.log('dbg @ step', i, c, flt, dbg, s, p, y, b, d, '0x' + c.toString(16));
+
+      a += String.fromCharCode(c);
+      b = d;
+    }
+
+    // encode sign + power + mantissa length in a Unicode char
+    // (i E {0..4} as maximum size FPC_ENC_MAXLEN=4 ==> 3 bits of length @ bits 13.14.15 in word)
+    //
+    // Bits in word:
+    // - 0..11: exponent; values -1024..+1023 with an offset of 1024 to make them all positive numbers
+    // - 12: sign
+    // - 13,14: length 1..4: the number of words following to define the mantissa
+    // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+    //       so we can only set this bit and have particular values in bits 0..14 at the same time
+    //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+    //
+    // Special values (with bit 15 set):
+    // - +Inf
+    // - -Inf
+    // - NaN
+    // - -0    (negative zero)
+    // - +0    (positive zero)
+    //
+    --i;
+    if (i > 3) {
+      throw new Error('fp encode length too large');
+    }
+    var h = p + 1024 + s + (i << 13 /* i * 8192 */ );   // brackets needed as + comes before <<   :-(
+    a = String.fromCharCode(h) + a;
+    //dbg[0] = h;
+    //console.log('dbg @ end', i, h, flt, dbg, s, p, y, b, '0x' + h.toString(16));
+    return a;
+  } else {
+    // -Inf / +Inf
+    if (flt > 0) {
+      return String.fromCharCode(FPC_ENC_POSITIVE_INFINITY);
+    } else {
+      return String.fromCharCode(FPC_ENC_NEGATIVE_INFINITY);
+    }
+  }
+}
+
+
+
+
+/*
+Performance Test of decode_fp_value() vs. vanilla JS:
+
+Test                                    Ops/sec
+
+CustomD :: v1                           21,885
+                                        ±1.24%
+                                        fastest
+
+ClassicD : parseFloat                   5,143
+                                        ±0.61%
+                                        76% slower
+
+ClassicD : multiply (= 1 * string)      4,744
+                                        ±0.49%
+                                        78% slower
+*/
+
+
+function decode_fp_value(s, opt) {
+  // sample JS code to decode a IEEE754 floating point value from a Unicode string.
+  //
+  // With provision to detect +0/-0 and +/-Inf and NaN
+  //
+  opt = opt || {};
+  opt.consumed_length = 1;
+
+  var c0 = s.charCodeAt(0);
+  //console.log('decode task: ', s, s.length, c0, '0x' + c0.toString(16));
+
+  // As we expect most encodings to be regular numbers, those will be in 0x0000..0x7FFF and
+  // we don't want to spend the least amount of time in the 'special values' overhead,
+  // which would be added overhead if we did check for those *first* instead of at the *same time*
+  // as we do here by looking at the top nibble immediately:
+  switch (c0 & 0xF000) {
+  case 0xF000:
+    // specials:
+    switch (c0) {
+    case FPC_ENC_POSITIVE_ZERO:
+      return 0;
+
+    case FPC_ENC_NEGATIVE_ZERO:
+      return -0;
+
+    case FPC_ENC_POSITIVE_INFINITY:
+      return Infinity;
+
+    case FPC_ENC_NEGATIVE_INFINITY:
+      return -Infinity;
+
+    case FPC_ENC_NAN:
+      return NaN;
+
+    default:
+      throw new Error('unknown Special Zone fp value');
+    }
+    break;
+
+  case 0x8000:
+  case 0x9000:
+  case 0xA000:
+  case 0xB000:
+  case 0xC000:
+    // 'human values' encoded as 'short floats':
+    //
+    // Bits in word:
+    // - 0..9: integer mantissa; values 0..1023
+    // - 10: sign
+    // - 11..14: exponent 0..9 with offset -3 --> -3..+6
+    // - 15: set to signal special values; this bit is also set for some special Unicode characters,
+    //       so we can only set this bit and have particular values in bits 0..14 at the same time
+    //       in order to prevent a collision with those Unicode specials at 0xD800..0xDFFF.
+    //
+    var dm = c0 & 0x03FF;      // 10 bits
+    var ds = c0 & 0x0400;      // bit 10 = sign
+    var dp = c0 & 0x7800;      // bits 11..14: exponent
+
+    //console.log('decode-short-0', ds, dm, '0x' + dp.toString(16), dp >>> 11, c0, '0x' + c0.toString(16));
+    dp >>>= 11;
+    dp -= 3 + 2;
+
+    var sflt = dm * Math.pow(10, dp);
+    if (ds) {
+      sflt = -sflt;
+    }
+    //console.log('decode-short-1', sflt, ds, dm, dp, c0, '0x' + c0.toString(16));
+    return sflt;
+
+  case 0xD000:
+    throw new Error('illegal fp encoding value in 0xDXXX unicode range');
+
+  default:
+    // 'regular' floating point values:
+    //
+    // Bits in word:
+    // - 0..11: exponent; values -1024..+1023 with an offset of 1024 to make them all positive numbers
+    // - 12: sign
+    // - 13,14: length 1..4: the number of words following to define the mantissa
+    // - 15: 0 (zero)
+    //
+    var len = c0 & 0x6000;
+    var vs = c0 & 0x1000;
+    var p = c0 & 0x0FFF;
+
+    p -= 1024;
+    //console.log('decode-normal-0', vs, p, len, '0x' + len.toString(16), c0, '0x' + c0.toString(16));
+
+    // we don't need to loop to decode the mantissa: we know how much stuff will be waiting for us still
+    // so this is fundamentally an unrolled loop coded as a switch/case:
+    var m;
+    var im;
+    // no need to shift len before switch()ing on it: it's still the same number of possible values anyway:
+    switch (len) {
+    case 0x0000:
+      // 1 more 15-bit word:
+      im = s.charCodeAt(1);
+      m = im / FPC_ENC_MODULO;
+      opt.consumed_length++;
+      //console.log('decode-normal-len=1', m, s.charCodeAt(1));
+      break;
+
+    case 0x2000:
+      // 2 more 15-bit words:
+      im = s.charCodeAt(1);
+      im <<= 15;
+      im |= s.charCodeAt(2);
+      m = im / (FPC_ENC_MODULO * FPC_ENC_MODULO);
+      opt.consumed_length += 2;
+      //console.log('decode-normal-len=2', m, s.charCodeAt(1), s.charCodeAt(2));
+      break;
+
+    case 0x4000:
+      // 3 more 15-bit words: WARNING: this doesn't fit in an *integer* of 31 bits any more,
+      // so we'll have to use floating point for at least one intermediate step!
+      //
+      // Oh, by the way, did you notice we use a Big Endian type encoding mechanism?  :-)
+      im = s.charCodeAt(1);
+      m = im / FPC_ENC_MODULO;
+      im = s.charCodeAt(2);
+      im <<= 15;
+      im |= s.charCodeAt(3);
+      m += im / (FPC_ENC_MODULO * FPC_ENC_MODULO * FPC_ENC_MODULO);
+      opt.consumed_length += 3;
+      //console.log('decode-normal-len=3', m, s.charCodeAt(1), s.charCodeAt(2), s.charCodeAt(3));
+      break;
+
+    case 0x6000:
+      // 4 more 15-bit words, where the last one doesn't use all bits. We don't use
+      // those surplus bits yet, so we're good to go when taking the entire word
+      // as a value, no masking required there.
+      //
+      // WARNING: this doesn't fit in an *integer* of 31 bits any more,
+      // so we'll have to use floating point for at least one intermediate step!
+      im = s.charCodeAt(1);
+      im <<= 15;
+      im |= s.charCodeAt(2);
+      m = im / (FPC_ENC_MODULO * FPC_ENC_MODULO);
+      im = s.charCodeAt(3);
+      im <<= 15;
+      im |= s.charCodeAt(4);
+      m += im / (FPC_ENC_MODULO * FPC_ENC_MODULO * FPC_ENC_MODULO * FPC_ENC_MODULO);
+      opt.consumed_length += 4;
+      //console.log('decode-normal-len=4', m, s.charCodeAt(1) / FPC_ENC_MODULO, s.charCodeAt(1), s.charCodeAt(2), s.charCodeAt(3), s.charCodeAt(4));
+      break;
+    }
+    //console.log('decode-normal-1', vs, m, p, opt.consumed_length);
+    m *= Math.pow(2, p);
+    m *= 2;
+    if (vs) {
+      m = -m;
+    }
+    //console.log('decode-normal-2', m);
+    return m;
+  }
+}
+
+
+
+
+
+console.info('fpcvt loaded');
+

--- a/example/jsperf/index.html
+++ b/example/jsperf/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="description" content="This is just a test document for Benchmark.js.">
-    <title>Benchmark.js test page | jsPerf</title>
+    <title id="test-title-1">???</title>
     <!-- https://jsperf.com/benchmark-js-test-page -->
     <link rel="stylesheet" href="main.css">
     <meta name="referrer" content="never">
@@ -14,7 +14,7 @@
   <body>
     <article>
       <hgroup>
-        <h1>Benchmark.js test page</h1>
+        <h1 id="test-title-2">???</h1>
         <h2>JavaScript performance comparison</h2>
       </hgroup>
 
@@ -26,46 +26,26 @@
 
       <section>
         <h2>Info</h2>
-        <p>
-          This is just a test document for Benchmark.js.
+        <p id="test-description">
+          ???
         </p>
+      </section>
+
+      <section>
+        <h2>Related tests</h2>
+        <ul id="related-tests">
+          <li>&lt;none&gt;</li>
+        </ul>
       </section>
 
       <section id="prep-code">
         <h2>Preparation code</h2>
-        <pre><code><span
-          class="sc2">&lt;<span class="kw2">div</span>&gt;</span>Lorem ipsum<span
-          class="sc2">&lt;<span class="sy0">/</span><span class="kw2">div</span>&gt;</span><br><span
-          class="sc2">&lt;<span class="kw2">script</span>&gt;</span><br>&nbsp; <span
-          class="kw2">var</span> arr <span class="sy0">=</span> <span class="br0">&#91;</span><span
-          class="nu0">1</span><span class="sy0">,</span> <span class="nu0">5</span><span
-          class="sy0">,</span> <span class="nu0">4</span><span class="sy0">,</span> <span
-          class="nu0">2</span><span class="sy0">,</span> <span class="nu0">3</span><span
-          class="br0">&#93;</span><span class="sy0">;</span><br><br>&nbsp; <span
-          class="kw2">function</span> init<span class="br0">&#40;</span><span
-          class="br0">&#41;</span> <span class="br0">&#123;</span><br>&nbsp;&nbsp;&nbsp; window.<span
-          class="me1">console</span> <span class="sy0">&amp;&amp;</span> console.<span
-          class="me1">log</span><span class="br0">&#40;</span><span class="st0">'init called'</span><span
-          class="br0">&#41;</span><span class="sy0">;</span><br>&nbsp; <span
-          class="br0">&#125;</span><br><span class="sc2">&lt;<span class="sy0">/</span><span
-          class="kw2">script</span>&gt;</span><br><span class="sc2">&lt;<span
-          class="kw2">script</span>></span><br>Benchmark.<span class="me1">prototype</span>.<span
-          class="me1">setup</span> <span class="sy0">=</span> <span class="kw2">function</span><span
-          class="br0">(</span><span class="br0">)</span> <span class="br0">{</span><br>&nbsp; window.<span
-          class="me1">foo</span> <span class="sy0">=</span> <span class="nu0">42</span><span
-          class="sy0">;</span><br>&nbsp; <span class="kw2">var</span> x <span
-          class="sy0">=</span> arr<span class="sy0">;</span><br><span class="br0">}</span><span
-          class="sy0">;</span><br><br>Benchmark.<span class="me1">prototype</span>.<span
-          class="me1">teardown</span> <span class="sy0">=</span> <span class="kw2">function</span><span
-          class="br0">(</span><span class="br0">) </span><span class="br0">{</span><br>&nbsp; window.<span
-          class="me1">foo</span> <span class="sy0">=</span> <span class="nu0">24</span><span
-          class="sy0">;</span><br><span class="br0">}</span><span class="sy0">;</span><br><span
-          class="sc2">&lt;<span class="sy0">/</span><span class="kw2">script</span>></span></code></pre>
+        <pre id="prep-code-display"><code>???</code></pre>
       </section>
 
       <section>
         <h2>Preparation code output</h2>
-        <div class="user-output">
+        <div id="user-output">
           <div>Lorem ipsum</div>
         </div>
       </section>
@@ -91,84 +71,7 @@
             <th title="Operations per second (higher is better)">Ops/sec</th>
           </tr>
           </thead>
-          <tbody>
-          <tr>
-            <th scope="row" id="title-1">
-              <div>Normal</div>
-            </th>
-            <td class="code">
-              <pre><code>x.<span class="me1">sort</span><span class="br0">&#40;</span><span
-                class="kw2">function</span><span class="br0">&#40;</span>a<span
-                class="sy0">,</span> b<span class="br0">&#41;</span> <span
-                class="br0">&#123;</span><br>&nbsp; <span class="kw1">return</span> a <span
-                class="sy0">-</span> b<span class="sy0">;</span><br><span
-                class="br0">&#125;</span><span class="br0">&#41;</span><span
-                class="sy0">;</span></code></pre>
-            </td>
-            <td id="results-1" class="results"></td>
-          </tr>
-          <tr>
-            <th scope="row" id="title-2">
-              <div>Exit Early</div>
-            </th>
-            <td class="code">
-              <pre><code>x.<span class="me1">sort</span><span class="br0">&#40;</span><span
-                class="kw2">function</span><span class="br0">&#40;</span>a<span
-                class="sy0">,</span> b<span class="br0">&#41;</span> <span
-                class="br0">&#123;</span><br>&nbsp; <span class="kw1">return</span> a <span
-                class="sy0">-</span> b<span class="sy0">;</span><br><span
-                class="br0">&#125;</span><span class="br0">&#41;</span><span
-                class="sy0">;</span><br><span class="kw1">return</span><span
-                class="sy0">;</span></code></pre>
-            </td>
-            <td id="results-2" class="results"></td>
-          </tr>
-          <tr>
-            <th scope="row" id="title-3">
-              <div>Async</div>
-            </th>
-            <td class="code">
-              <pre><code><strong class="co1">// async test</strong><br>setTimeout<span
-                class="br0">&#40;</span><span class="kw2">function</span><span
-                class="br0">&#40;</span><span class="br0">&#41;</span> <span
-                class="br0">&#123;</span><br>&nbsp; deferred.<span
-                class="me1">resolve</span><span class="br0">&#40;</span><span
-                class="br0">&#41;</span><span class="sy0">;</span><br><span
-                class="br0">&#125;</span><span class="sy0">,</span> <span
-                class="nu0">10</span><span class="br0">&#41;</span><span
-                class="sy0">;</span></code></pre>
-            </td>
-            <td id="results-3" class="results"></td>
-          </tr>
-          <tr>
-            <th scope="row" id="title-4">
-              <div>Error</div>
-            </th>
-            <td class="code">
-              <pre><code>x.<span class="me1">foo</span><span class="br0">&#40;</span><span
-                class="br0">&#41;</span><span class="sy0">;</span> <span
-                class="co1">// unknown method</span></code></pre>
-            </td>
-            <td id="results-4" class="results"></td>
-          </tr>
-          <tr>
-            <th scope="row" id="title-5">
-              <div>Comments</div>
-            </th>
-            <td class="code">
-              <pre><code><span class="co1">// comments at start</span><br>x.<span
-                class="me1">reverse</span><span class="br0">&#40;</span><span
-                class="br0">&#41;</span>.<span class="me1">sort</span><span
-                class="br0">&#40;</span><span class="kw2">function</span><span
-                class="br0">&#40;</span>a<span class="sy0">,</span> b<span
-                class="br0">&#41;</span> <span class="br0">&#123;</span><br>&nbsp; <span
-                class="kw1">return</span> a <span class="sy0">-</span> b<span
-                class="sy0">;</span><br><span class="br0">&#125;</span><span
-                class="br0">&#41;</span><span class="sy0">;</span><br><span
-                class="co1">// comments at end</span></code></pre>
-            </td>
-            <td id="results-5" class="results"></td>
-          </tr>
+          <tbody id="test-rows-container">
           </tbody>
         </table>
 
@@ -214,6 +117,11 @@
           </form>
         </div>
       </section>
+
+      <section>
+        <h2>A list of all available tests</h2>
+        <div id="test-catalog"></div>
+      </section>
     </article>
 
     <footer>
@@ -229,55 +137,70 @@
 
     <script src="../../node_modules/lodash/lodash.js"></script>
     <script src="../../node_modules/platform/platform.js"></script>
+    <script src="../../node_modules/json5/lib/json5.js"></script>
     <script src="../../benchmark.js"></script>
     <script src="ui.js"></script>
+    <script src="../../plugin/globalEval.js"></script>
     <script src="../../plugin/ui.browserscope.js"></script>
     <script>
-      var arr = [1, 5, 4, 2, 3];
-
-      function init() {
-        window.console && console.log('init called');
-      }
+      // ui.browserscope.key = 'agt1YS1wcm9maWxlcnIRCxIEVGVzdBiAgICAiI2QCgw';
+      ui.browserscope.selector = '#bs-results';
+    </script>
+    <script id="test-row-template" type="text/plain">
+          <tr>
+            <th scope="row" id="title-ID">
+              <div>Comments</div>
+            </th>
+            <td id="code-ID" class="code">
+              <pre><code>???</code></pre>
+            </td>
+            <td id="results-ID" class="results"></td>
+          </tr>
     </script>
     <script>
-      ui.browserscope.key = 'agt1YS1wcm9maWxlcnIRCxIEVGVzdBiAgICAiI2QCgw';
-      ui.browserscope.selector = '#bs-results';
+      // https://codepen.io/KryptoniteDove/post/load-json-file-locally-using-pure-javascript
+      function loadTestFile(callback) {
+        var xobj = new XMLHttpRequest();
+        //xobj.overrideMimeType("application/json");
+        var testfile = window.location.hash || 'testfile=test0001.json5';
+        testfile = testfile.replace(/^.*testfile=(.*?\.json5?).*$/, '$1');
+        console.info('loading test spec file:', testfile);
+        xobj.open('GET', testfile, true);
+        xobj.onreadystatechange = function () {
+          if (xobj.readyState === 4 && xobj.status == "200") {
+            callback(xobj.responseText, testfile);
+          }
+        };
+        xobj.send(null);
+      }
+      function loadCatalogFile() {
+        var xobj = new XMLHttpRequest();
+        var testfile = 'test-catalog.txt';
+        xobj.open('GET', testfile, true);
+        xobj.onreadystatechange = function () {
+          if (xobj.readyState === 4 && xobj.status == "200") {
+            var lst = xobj.responseText
+            .replace(/\r\n?/g, '\n')
+            .split('\n')
+            .filter(function (l) {
+              return (l.trim() !== '');
+            })
+            .map(function (l) {
+              return '<li><a href="?' + ('' + Math.random()).substr(-3) + '#testfile=' + l.trim() + '">' + l.trim().replace(/\.json5?/, '') + '</a></li>';
+            });
 
-      ui.add('Normal', '\
-        x.sort(function(a, b) {\n\
-          return a - b;\n\
-        });'
-      )
-      .add('Exit Early', '\
-        x.sort(function(a, b) {\n\
-          return a - b;\n\
-        });\n\
-        return;'
-      )
-      .add('Async', {
-        'defer': true,
-        'fn': '\
-          setTimeout(function() {\n\
-            deferred.resolve();\n\
-          }, 10);'
-      })
-      .add('Error', '\
-        x.foo(); // unknown method'
-      )
-      .add('Comments', '\
-        // comments at start\n\
-        x.reverse().sort(function(a, b) {\n\
-          return a - b;\n\
-        });\n\
-        // comments at end'
-      );
+            setHTML('test-catalog', '<ul>' + lst.join('\n') + '</ul>');
+          }
+        };
+        xobj.send(null);
+      }
 
-      Benchmark.prototype.setup = '\
-        window.foo = 42;\n\
-        var x = arr;';
-
-      Benchmark.prototype.teardown = '\
-        window.foo = 24;';
+      loadTestFile(function benchmark_load_cb(response, file_uri) {
+        // Parse JSON string into object
+        var actual_JSON = JSON5.parse(response);
+        ui.initFromJSON(actual_JSON);
+      });
+      loadCatalogFile();
     </script>
   </body>
 </html>

--- a/example/jsperf/main.css
+++ b/example/jsperf/main.css
@@ -560,6 +560,7 @@ footer {
   body {
     margin: 0;
     border: 0;
+    padding: 0;
   }
 
   body, #comments .meta {

--- a/example/jsperf/test-catalog.txt
+++ b/example/jsperf/test-catalog.txt
@@ -1,0 +1,6 @@
+test0001.json5
+test0002.json5
+test0003.json5
+test0004-fp-encode-only.json5
+test0005-fp-decode-only.json5
+test0006-fp-encode-plus-decode.json5

--- a/example/jsperf/test0001.json5
+++ b/example/jsperf/test0001.json5
@@ -1,0 +1,83 @@
+/*
+    Preparation code chunk:
+
+    <div>Lorem ipsum</div>                                              --> user-output
+    <script>                                                            --> prep-spec
+      var arr = [1, 5, 4, 2, 3];
+
+      function init() {
+        window.console && console.log('init called');
+      }
+    <\/script>
+    <script>                                                            --> setup-spec
+    Benchmark.prototype.setup = function() {
+      window.foo = 42;
+      var x = arr;
+    };
+
+    Benchmark.prototype.teardown = function() {
+      window.foo = 24;
+    };
+    <\/script>
+*/
+
+{
+  title: 'Benchmark.js test page (for jsPerf & alternatives) :: demo test #1',
+  description: 'This is just a test document for Benchmark.js.',
+  browserscope_API_key: 'ahBzfnVhLXByb2ZpbGVyLWhychELEgRUZXN0GICA4LDez_EKDA',
+
+  HTML: "<div>Lorem ipsum</div>",
+  init: "\
+      var arr = [1, 5, 4, 2, 3];\n\
+\n\
+      function init() {\n\
+        window.console && console.log('init called');\n\
+      }\
+        ",
+  tests: [
+    {
+      name: 'Normal', 
+      fn: '\
+        x.sort(function(a, b) {\n\
+          return a - b;\n\
+        });'
+    },
+    {
+      name: 'Exit Early', 
+      fn: '\
+        x.sort(function(a, b) {\n\
+          return a - b;\n\
+        });\n\
+        return;'
+    },
+    { 
+      name: 'Async', 
+      'defer': true,
+      'fn': '\
+        setTimeout(function() {\n\
+          deferred.resolve();\n\
+        }, 10);'
+    },
+    {
+      name: 'Error', 
+      fn: '\
+        x.foo(); // unknown method'
+    },
+    {
+      name: 'Comments', 
+      fn: '\
+        // comments at start\n\
+        x.reverse().sort(function(a, b) {\n\
+          return a - b;\n\
+        });\n\
+        // comments at end'
+    }
+  ],
+  setup: '\
+        Benchmark.prototype.setup = window.foo = 42;\n\
+        var x = arr;\n\
+        ',
+  teardown: '\
+        Benchmark.prototype.teardown = window.foo = 24;\n\
+        '
+}

--- a/example/jsperf/test0002.json5
+++ b/example/jsperf/test0002.json5
@@ -1,0 +1,113 @@
+/*
+    Preparation code chunk:
+
+    <div>Lorem ipsum</div>                                              --> user-output
+    <script>                                                            --> prep-spec
+      var arr = [1, 5, 4, 2, 3];
+
+      function init() {
+        window.console && console.log('init called');
+      }
+    <\/script>
+    <script>                                                            --> setup-spec
+    Benchmark.prototype.setup = function() {
+      window.foo = 42;
+      var x = arr;
+    };
+
+    Benchmark.prototype.teardown = function() {
+      window.foo = 24;
+    };
+    <\/script>
+*/
+
+{
+  title: 'test #2',
+  description: 'bla bla bla',
+
+  HTML: "<div>Lorem ipsum</div>",
+  init: "\
+      var arr = [1, 5, 4, 2, 3];\n\
+      var obj = {a: 1, b: 2, c: 3};\n\
+      var rv = 0;\n\
+\n\
+      function init() {\n\
+        window.console && console.log('init called');\n\
+      }\n\
+\n\
+      function t_global_scope() {\n\
+        if (!arr[7]) {\n\
+          arr[7] = 1;\n\
+        } else {\n\
+          arr[7] += arr[2];\n\
+        }\n\
+        if (!obj.s) {\n\
+          obj.s = 1;\n\
+        } else {\n\
+          obj.s += obj.b;\n\
+        }\n\
+        return arr[7] + obj.s;\n\
+      }\n\
+\n\
+      function t_closure_scope() {\n\
+        var arr = [1, 5, 4, 2, 3];\n\
+        var obj = {a: 1, b: 2, c: 3};\n\
+\n\
+        function t_do() {\n\
+          if (!arr[7]) {\n\
+            arr[7] = 1;\n\
+          } else {\n\
+            arr[7] += arr[2];\n\
+          }\n\
+          if (!obj.s) {\n\
+            obj.s = 1;\n\
+          } else {\n\
+            obj.s += obj.b;\n\
+          }\n\
+          return arr[7] + obj.s;\n\
+        }\n\
+\n\
+        return t_do;\n\
+      }\n\
+      var t_closure_scope_f = t_closure_scope();\n\
+\n\
+      function t_pass_by_ref(arr, obj) {\n\
+        if (!arr[7]) {\n\
+          arr[7] = 1;\n\
+        } else {\n\
+          arr[7] += arr[2];\n\
+        }\n\
+        if (!obj.s) {\n\
+          obj.s = 1;\n\
+        } else {\n\
+          obj.s += obj.b;\n\
+        }\n\
+        return arr[7] + obj.s;\n\
+      }\n\
+      ",
+  tests: [
+    {
+      name: 'Global Scope', 
+      fn: '\
+        rv += t_global_scope();'
+    },
+    {
+      name: 'Parent / Closure', 
+      fn: '\
+        rv += t_closure_scope_f();'
+    },
+    { 
+      name: 'CPS / Pass By Reference', 
+      'defer': false,
+      'fn': '\
+        rv += t_pass_by_ref(arr, obj);'
+    },
+  ],
+  setup: "\
+        Benchmark.prototype.setup = function () { rv = 0; };\n\
+        ",
+  teardown: "\
+        var pulse_counter = 0;\n\
+        Benchmark.prototype.teardown = function () { pulse_counter++; if (pulse_counter >= 1000) { pulse_counter = 0; console.log('rv = ', rv); } };\n\
+        "
+}

--- a/example/jsperf/test0003.json5
+++ b/example/jsperf/test0003.json5
@@ -1,0 +1,148 @@
+{
+  title: 'test #3 : custom FP value serialization',
+  description: 'determining the speed loss factor when we serialize FP (and integer) values to a custom string format vs. standard print+parse.',
+
+  HTML: "",
+  init: "\
+      // simply injecting script tag to DOM via innerHTML doesn't work, so we have to do it this way:\n\
+      [\n\
+        'fpcvt.js',\n\
+      ].forEach(function (src) {\n\
+        var script = document.createElement('script');\n\
+        script.src = src;\n\
+        document.head.appendChild(script);\n\
+      });\n\
+\n\
+      //var x = Math.random();\n\
+      //var y = Math.tan(x - 0.5);\n\
+      //var z = Math.pow(2, 100 * y);\n\
+      //var a = (1 + Math.random() * 21) | 0;\n\
+      //var b = z.toPrecision(a); // accepted prec range: 1..21\n\
+      //console.log(x, y, z, a, b);\n\
+\n\
+      const test_serialization = true;\n\
+\n\
+      var data = [];\n\
+      var serialized_data = [];\n\
+      var serialized_data2 = [];\n\
+      var data_length = 0;\n\
+\n\
+      function init() {\n\
+        if (data_length) return;\n\
+\n\
+        for (var i = 0, l = 1000; i < l; i++) {\n\
+          var x = Math.random();\n\
+          var y = Math.tan(x - 0.5);\n\
+          var z = Math.pow(2, 100 * y);\n\
+          var a = (1 + Math.random() * 21) | 0;\n\
+          var b = z.toPrecision(a);\n\
+          data[i] = parseFloat(b);\n\
+        }\n\
+        data_length = l;\n\
+\n\
+        window.console && console.log('init:: data set:', data.slice(0, 20), '...');\n\
+      }\n\
+\n\
+      // serialize / deserialize functions:\n\
+      function classic_s_1(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toString();\n\
+        }\n\
+      }\n\
+      function classic_s_2(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = '' + flt;\n\
+        }\n\
+      }\n\
+      function classic_s_3(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toPrecision(16);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_1(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_d_1(serialized_data, len, data) {\n\
+        var cps = {};\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = decode_fp_value(fltstr, cps);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_1(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = parseFloat(fltstr);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_2(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = 1 * fltstr;\n\
+        }\n\
+      }\n\
+      ",
+  tests: [
+    {
+      name: 'Classic : toString', 
+      fn: '\
+        classic_s_1(data, data_length, serialized_data);'
+    },
+    {
+      name: 'Classic : add to string', 
+      fn: '\
+        classic_s_2(data, data_length, serialized_data);'
+    },
+    { 
+      name: 'Classic :: toPrecision(max)', 
+      'fn': '\
+        classic_s_3(data, data_length, serialized_data);'
+    },
+    { 
+      name: 'Custom :: v1', 
+      'fn': '\
+        custom_s_1(data, data_length, serialized_data2);'
+    },
+    { 
+      name: 'CustomD :: v1', 
+      'fn': '\
+        custom_d_1(serialized_data2, data_length, data);'
+    },
+    {
+      name: 'ClassicD : parseFloat', 
+      fn: '\
+        classic_d_1(serialized_data, data_length, data);'
+    },
+    {
+      name: 'ClassicD : multiply', 
+      fn: '\
+        classic_d_2(serialized_data, data_length, data);'
+    },
+  ],
+  setup: "\
+        Benchmark.prototype.setup = function () {\n\
+          classic_s_1(data, data_length, serialized_data);\n\
+          custom_s_1(data, data_length, serialized_data2);\n\
+        };\n\
+        ",
+  teardown: "\
+        Benchmark.prototype.teardown = function () { };\n\
+        "
+}

--- a/example/jsperf/test0004-fp-encode-only.json5
+++ b/example/jsperf/test0004-fp-encode-only.json5
@@ -1,0 +1,174 @@
+{
+  title: 'test #3 : custom FP value serialization',
+  description: 'determining the speed loss factor when we serialize FP (and integer) values to a custom string format vs. standard print+parse.',
+  related: [
+    'test0003.json5',
+    'test0005-fp-decode-only.json5',
+    'test0006-fp-encode-plus-decode.json5',
+  ],
+
+  HTML: "",
+  init: "\
+      // simply injecting script tag to DOM via innerHTML doesn't work, so we have to do it this way:\n\
+      [\n\
+        'fpcvt.js',\n\
+        'fpcvt-alt1.js',\n\
+        'fpcvt-alt2.js',\n\
+      ].forEach(function (src) {\n\
+        var script = document.createElement('script');\n\
+        script.src = src;\n\
+        document.head.appendChild(script);\n\
+      });\n\
+\n\
+      //var x = Math.random();\n\
+      //var y = Math.tan(x - 0.5);\n\
+      //var z = Math.pow(2, 100 * y);\n\
+      //var a = (1 + Math.random() * 21) | 0;\n\
+      //var b = z.toPrecision(a); // accepted prec range: 1..21\n\
+      //console.log(x, y, z, a, b);\n\
+\n\
+      const test_serialization = true;\n\
+\n\
+      var data = [];\n\
+      var serialized_data = [];\n\
+      var serialized_data2 = [];\n\
+      var data_length = 0;\n\
+\n\
+      function init() {\n\
+        if (data_length) return;\n\
+\n\
+        for (var i = 0, l = 1000; i < l; i++) {\n\
+          var x = Math.random();\n\
+          var y = Math.tan(x - 0.5);\n\
+          var z = Math.pow(2, 100 * y);\n\
+          var a = (1 + Math.random() * 21) | 0;\n\
+          var b = z.toPrecision(a);\n\
+          data[i] = parseFloat(b);\n\
+        }\n\
+        data_length = l;\n\
+\n\
+        window.console && console.log('init:: data set:', data.slice(0, 20), '...');\n\
+      }\n\
+\n\
+      // serialize / deserialize functions:\n\
+      function classic_s_1(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toString();\n\
+        }\n\
+      }\n\
+      function classic_s_2(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = '' + flt;\n\
+        }\n\
+      }\n\
+      function classic_s_3(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toPrecision(16);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_1(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_2(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value2(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_3(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value3(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_d_1(serialized_data, len, data) {\n\
+        var cps = {};\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = decode_fp_value(fltstr, cps);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_1(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = parseFloat(fltstr);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_2(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = 1 * fltstr;\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_3(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = JSON.parse(fltstr);\n\
+        }\n\
+      }\n\
+      ",
+  tests: [
+    {
+      name: 'Classic : toString', 
+      fn: '\
+        classic_s_1(data, data_length, serialized_data);'
+    },
+    {
+      name: 'Classic : add to string', 
+      fn: '\
+        classic_s_2(data, data_length, serialized_data);'
+    },
+    { 
+      name: 'Classic :: toPrecision(max)', 
+      'fn': '\
+        classic_s_3(data, data_length, serialized_data);'
+    },
+    { 
+      name: 'Custom :: v1', 
+      'fn': '\
+        custom_s_1(data, data_length, serialized_data2);'
+    },
+    { 
+      name: 'Custom :: v2', 
+      'fn': '\
+        custom_s_2(data, data_length, serialized_data2);'
+    },
+    { 
+      name: 'Custom :: v3', 
+      'fn': '\
+        custom_s_3(data, data_length, serialized_data2);'
+    },
+  ],
+  setup: "\
+        Benchmark.prototype.setup = function () {\n\
+          classic_s_1(data, data_length, serialized_data);\n\
+          custom_s_1(data, data_length, serialized_data2);\n\
+        };\n\
+        ",
+  teardown: "\
+        Benchmark.prototype.teardown = function () { };\n\
+        "
+}

--- a/example/jsperf/test0005-fp-decode-only.json5
+++ b/example/jsperf/test0005-fp-decode-only.json5
@@ -1,0 +1,164 @@
+{
+  title: 'test #3 : custom FP value serialization',
+  description: 'determining the speed loss factor when we serialize FP (and integer) values to a custom string format vs. standard print+parse.',
+  related: [
+    'test0003.json5',
+    'test0004-fp-encode-only.json5',
+    'test0006-fp-encode-plus-decode.json5',
+  ],
+
+  HTML: "",
+  init: "\
+      // simply injecting script tag to DOM via innerHTML doesn't work, so we have to do it this way:\n\
+      [\n\
+        'fpcvt.js',\n\
+        'fpcvt-alt1.js',\n\
+        'fpcvt-alt2.js',\n\
+      ].forEach(function (src) {\n\
+        var script = document.createElement('script');\n\
+        script.src = src;\n\
+        document.head.appendChild(script);\n\
+      });\n\
+\n\
+      //var x = Math.random();\n\
+      //var y = Math.tan(x - 0.5);\n\
+      //var z = Math.pow(2, 100 * y);\n\
+      //var a = (1 + Math.random() * 21) | 0;\n\
+      //var b = z.toPrecision(a); // accepted prec range: 1..21\n\
+      //console.log(x, y, z, a, b);\n\
+\n\
+      const test_serialization = true;\n\
+\n\
+      var data = [];\n\
+      var serialized_data = [];\n\
+      var serialized_data2 = [];\n\
+      var data_length = 0;\n\
+\n\
+      function init() {\n\
+        if (data_length) return;\n\
+\n\
+        for (var i = 0, l = 1000; i < l; i++) {\n\
+          var x = Math.random();\n\
+          var y = Math.tan(x - 0.5);\n\
+          var z = Math.pow(2, 100 * y);\n\
+          var a = (1 + Math.random() * 21) | 0;\n\
+          var b = z.toPrecision(a);\n\
+          data[i] = parseFloat(b);\n\
+        }\n\
+        data_length = l;\n\
+\n\
+        window.console && console.log('init:: data set:', data.slice(0, 20), '...');\n\
+      }\n\
+\n\
+      // serialize / deserialize functions:\n\
+      function classic_s_1(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toString();\n\
+        }\n\
+      }\n\
+      function classic_s_2(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = '' + flt;\n\
+        }\n\
+      }\n\
+      function classic_s_3(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          serialized_data[i] = flt.toPrecision(16);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_1(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_2(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value2(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_s_3(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          serialized_data[ii] = encode_fp_value3(flt);\n\
+        }\n\
+      }\n\
+\n\
+      function custom_d_1(serialized_data, len, data) {\n\
+        var cps = {};\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = decode_fp_value(fltstr, cps);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_1(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = parseFloat(fltstr);\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_2(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = 1 * fltstr;\n\
+        }\n\
+      }\n\
+\n\
+      function classic_d_3(serialized_data, len, data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var fltstr = serialized_data[ii];\n\
+\n\
+          data[ii] = JSON.parse(fltstr);\n\
+        }\n\
+      }\n\
+      ",
+  tests: [
+    { 
+      name: 'CustomD :: v1', 
+      'fn': '\
+        custom_d_1(serialized_data2, data_length, data);'
+    },
+    {
+      name: 'ClassicD : parseFloat', 
+      fn: '\
+        classic_d_1(serialized_data, data_length, data);'
+    },
+    {
+      name: 'ClassicD : multiply', 
+      fn: '\
+        classic_d_2(serialized_data, data_length, data);'
+    },
+    {
+      name: 'ClassicD : JSON.parse', 
+      fn: '\
+        classic_d_3(serialized_data, data_length, data);'
+    },
+  ],
+  setup: "\
+        Benchmark.prototype.setup = function () {\n\
+          classic_s_1(data, data_length, serialized_data);\n\
+          custom_s_1(data, data_length, serialized_data2);\n\
+        };\n\
+        ",
+  teardown: "\
+        Benchmark.prototype.teardown = function () { };\n\
+        "
+}

--- a/example/jsperf/test0006-fp-encode-plus-decode.json5
+++ b/example/jsperf/test0006-fp-encode-plus-decode.json5
@@ -1,0 +1,131 @@
+{
+  title: 'test #3 : custom FP value serialization',
+  description: 'determining the speed loss factor when we serialize FP (and integer) values to a custom string format vs. standard print+parse.\n\nThis particular test compares the <em>back and forth conversion of floating point values to strings</em> using a series of random numbers.</p>\n<blockquote>Note: I ignore the probable speedups available in the "custom" encoders when they hit <em>usual numbers</em>, e.g. 1 or 12 or 0.3 and ditto for <em>special values</em> such as <code>NaN</code> and <code>+/-Infinity</code> as the random set has very low probability of generating any of these.</blockquote>\n<p>The point of the test is to see who is the fastest <strong>combo</strong> on the block for the <def>float → string → float</def> conversion process.',
+  related: [
+    'test0003.json5',
+    'test0004-fp-encode-only.json5',
+    'test0005-fp-decode-only.json5',
+  ],
+
+  HTML: "",
+  init: "\
+      // simply injecting script tag to DOM via innerHTML doesn't work, so we have to do it this way:\n\
+      [\n\
+        'fpcvt.js',\n\
+        'fpcvt-alt1.js',\n\
+        'fpcvt-alt2.js',\n\
+      ].forEach(function (src) {\n\
+        var script = document.createElement('script');\n\
+        script.src = src;\n\
+        document.head.appendChild(script);\n\
+      });\n\
+\n\
+      //var x = Math.random();\n\
+      //var y = Math.tan(x - 0.5);\n\
+      //var z = Math.pow(2, 100 * y);\n\
+      //var a = (1 + Math.random() * 21) | 0;\n\
+      //var b = z.toPrecision(a); // accepted prec range: 1..21\n\
+      //console.log(x, y, z, a, b);\n\
+\n\
+      const test_serialization = true;\n\
+\n\
+      var data = [];\n\
+      var serialized_data = [];\n\
+      var serialized_data2 = [];\n\
+      var data_length = 0;\n\
+\n\
+      function init() {\n\
+        if (data_length) return;\n\
+\n\
+        for (var i = 0, l = 1000; i < l; i++) {\n\
+          var x = Math.random();\n\
+          var y = Math.tan(x - 0.5);\n\
+          var z = Math.pow(2, 100 * y);\n\
+          var a = (1 + Math.random() * 21) | 0;\n\
+          var b = z.toPrecision(a);\n\
+          data[i] = parseFloat(b);\n\
+        }\n\
+        data_length = l;\n\
+\n\
+        window.console && console.log('init:: data set:', data.slice(0, 20), '...');\n\
+      }\n\
+\n\
+      // serialize / deserialize functions:\n\
+      function classic_1(data, len, serialized_data) {\n\
+        for (var i = 0; i < len; i++) {\n\
+          var flt = data[i];\n\
+\n\
+          var s = '' + flt; // fastest solution for encode\n\
+          var t = parseFloat(s); // fastest solution for decode\n\
+          //if (t !== flt) {\n\
+          //  console.error('classic enc/dec mismatch: ', flt, s, t);\n\
+          //}\n\
+        }\n\
+      }\n\
+\n\
+      function custom_1(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          var s = encode_fp_value(flt);\n\
+          var t = decode_fp_value(s);\n\
+          //if (t !== flt) {\n\
+          //  console.error('custom enc/dec mismatch: ', flt, s, t);\n\
+          //}\n\
+        }\n\
+      }\n\
+\n\
+      function custom_2(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          var s = encode_fp_value2(flt);\n\
+          var t = decode_fp_value(s);\n\
+          //if (t !== flt) {\n\
+          //  console.error('custom enc/dec mismatch: ', flt, s, t);\n\
+          //}\n\
+        }\n\
+      }\n\
+\n\
+      function custom_3(data, len, serialized_data) {\n\
+        for (var ii = 0; ii < len; ii++) {\n\
+          var flt = data[ii];\n\
+\n\
+          var s = encode_fp_value3(flt);\n\
+          var t = decode_fp_value(s);\n\
+          //if (t !== flt) {\n\
+          //  console.error('custom enc/dec mismatch: ', flt, s, t);\n\
+          //}\n\
+        }\n\
+      }\n\
+      ",
+  tests: [
+    {
+      name: 'Classic', 
+      fn: '\
+        classic_1(data, data_length, serialized_data);'
+    },
+    {
+      name: 'Custom : v1', 
+      fn: '\
+        custom_1(data, data_length, serialized_data);'
+    },
+    {
+      name: 'Custom : v2', 
+      fn: '\
+        custom_2(data, data_length, serialized_data);'
+    },
+    {
+      name: 'Custom : v3', 
+      fn: '\
+        custom_3(data, data_length, serialized_data);'
+    },
+  ],
+  setup: "\
+        Benchmark.prototype.setup = function () {\n\
+        };\n\
+        ",
+  teardown: "\
+        Benchmark.prototype.teardown = function () { };\n\
+        "
+}

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "repository": "bestiejs/benchmark.js",
   "scripts": {
     "doc": "docdown benchmark.js doc/README.md toc='categories' url=\"https://github.com/bestiejs/benchmark.js/blob/${npm_package_version}/benchmark.js\" title=\"<a href=\\\"https://benchmarkjs.com/\\\">Benchmark.js</a> <span>v${npm_package_version}</span>\" hash='github'",
-    "test": "node test/test"
+    "test": "node test/test",
+    "server": "live-server --cors"
   },
   "dependencies": {
+    "json5": "github:GerHobbelt/json5#0.5.1-12",
     "lodash": "^4.14.0",
     "platform": "^1.3.1"
   },
@@ -25,6 +27,7 @@
     "coveralls": "^2.11.11",
     "docdown": "~0.6.1",
     "istanbul": "0.4.4",
+    "live-server": "^1.0.0",
     "qunit-extras": "^2.1.0",
     "qunitjs": "^2.0.1",
     "requirejs": "^2.2.0"

--- a/plugin/globalEval.js
+++ b/plugin/globalEval.js
@@ -1,0 +1,34 @@
+// http://perfectionkills.com/global-eval-what-are-the-options/#evaling_in_global_scope
+
+var globalEval = (function() {
+
+  var isIndirectEvalGlobal = (function(original, Object) {
+    try {
+      // Does `Object` resolve to a local variable, or to a global, built-in `Object`,
+      // reference to which we passed as a first argument?
+      return (1,eval)('Object') === original;
+    }
+    catch(err) {
+      // if indirect eval errors out (as allowed per ES3), then just bail out with `false`
+      return false;
+    }
+  })(Object, 123);
+
+  if (isIndirectEvalGlobal) {
+
+    // if indirect eval executes code globally, use it
+    return function(expression) {
+      return (1,eval)(expression);
+    };
+  }
+  else if (typeof window.execScript !== 'undefined') {
+
+    // if `window.execScript exists`, use it
+    return function(expression) {
+      return window.execScript(expression);
+    };
+  }
+
+  // otherwise, globalEval is `undefined` since nothing is returned
+})();
+

--- a/plugin/ui.browserscope.js
+++ b/plugin/ui.browserscope.js
@@ -985,7 +985,8 @@
 
   /*--------------------------------------------------------------------------*/
 
-  addListener(window, 'load', function() {
+  // was: addListener(window, 'load', function() {
+  ui.browserscope.init = function initBrowserscopeFrame() {
     var me = ui.browserscope,
         key = me.key,
         placeholder = key && query(me.selector)[0];
@@ -1053,7 +1054,7 @@
         'callback:ui.browserscope.load' +
       '}]' +
     '}'), idoc);
-  });
+  };
 
   // hide the chart while benchmarks are running
   ui.on('start', function() {


### PR DESCRIPTION
So that the example is more usable -- I now use it as a local replacement (if a very crude one) for the jsperf.com site which ***************************.

SHA-1: f7442b62a8c7d7da94f99bc08773d63f61a3ac70

* augmented/updated the jsperf example/demo:

- now tests can be specified using JSON5 format files (JSON5 instead of JSON because it's handy to comment your tests and string encoding is easier ==> easier to write tests in that format when you lack an editor (such as jsperf.com ;-) )

- `npm run server` will start a live-reload featuring local http server to help run tests / debug benchmark + /example/jsperf/ code.

- as the browserscope API key now is specified in the loaded test file (json5) the moment in time when to init browserscope also changes: this must be done later than on window.load ==> minimal api change there and explicit init call in /exampl/jsperf/ui.js

This code is cherrypicked from GerHobbelt/benchmark.js#master -- when you compare them you'll find that I got rid of browserscope ultimately (SHA-1: ed05347d672e5d15457b519a8cb1cb1f4d81f452)


SHA-1: fa21f0a048b8b3561dfaf17ce36188c5b00c382d

* - add a few more benchmark tests to the /example/jsperf/ directory

- this showcases the use of the rudimentary `./build-jsperf.sh` shell script, which updates the `/example/jsperf/test-catalog.txt` file

- this showcases the use of that catalog file in `/example/jsperf/index.html`: now you get a list of all available tests; no description or any other fanciness: this is bare bones.
