### PR TITLE
example/jsperf/ui.js: report both `slower by xx%` and `slower by a factor of X`

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1530,8 +1530,18 @@
           result = bench.name || (_.isNaN(id) ? id : '<Test #' + id + '>');
 
       if (error) {
-        result += ': ' + join(error);
-      } else {
+        var errorStr;
+        if (!_.isObject(error)) {
+          errorStr = String(error);
+        } else if (!_.isError(Error)) {
+          errorStr = join(error);
+        } else {
+          // Error#name and Error#message properties are non-enumerable.
+          errorStr = join(_.assign({ 'name': error.name, 'message': error.message }, error));
+        }
+        result += ': ' + errorStr;
+      }
+      else {
         result += ' x ' + formatNumber(hz.toFixed(hz < 100 ? 2 : 0)) + ' ops/sec ' + pm +
           stats.rme.toFixed(2) + '% (' + size + ' run' + (size == 1 ? '' : 's') + ' sampled)';
       }

--- a/example/jsperf/main.css
+++ b/example/jsperf/main.css
@@ -345,7 +345,7 @@ footer {
   width: 232px;
   height: 39px;
   filter: none;
-  background: url(//www.browserscope.org/static/img/logo.png) 0 0 no-repeat;
+  background: url(https://www.browserscope.org/static/img/logo.png) 0 0 no-repeat;
 }
 
 #bs-ua {

--- a/example/jsperf/ui.js
+++ b/example/jsperf/ui.js
@@ -704,7 +704,7 @@
     setTimeout(function() {
       ui.off();
       ui.browserscope.post = function() {};
-      _.invoke(ui.benchmarks, 'off');
+      _.invokeMap(ui.benchmarks, 'off');
     }, 1);
   }
 

--- a/example/jsperf/ui.js
+++ b/example/jsperf/ui.js
@@ -223,7 +223,6 @@
         addListener('run', 'click', handlers.button.run);
 
         setHTML('run', texts.run.ready);
-        setHTML('user-agent', Benchmark.platform);
         setStatus(texts.status.ready);
 
         // prefill author details

--- a/example/jsperf/ui.js
+++ b/example/jsperf/ui.js
@@ -560,10 +560,11 @@
       if (_.indexOf(fastest, bench) > -1) {
         // mark fastest
         addClass(cell, text);
+        text += '<br>(&#x2715;&#x00a0;1)';
       }
       else {
         text = isFinite(hz)
-          ? formatNumber(percent < 1 ? percent.toFixed(2) : Math.round(percent)) + '% slower'
+          ? formatNumber(percent < 1 ? percent.toFixed(2) : Math.round(percent)) + '% slower<br>(&#x2715;&#x00a0;' + (fastestHz / hz).toFixed(1) + ')'
           : '';
 
         // mark slowest

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "platform": "^1.3.1"
   },
   "devDependencies": {
-    "coveralls": "^2.11.11",
+    "coveralls": "^2.11.12",
     "docdown": "~0.6.1",
     "istanbul": "0.4.4",
     "qunit-extras": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "node test/test"
   },
   "dependencies": {
-    "lodash": "^4.13.1",
+    "lodash": "^4.14.0",
     "platform": "^1.3.1"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "docdown": "~0.6.1",
     "istanbul": "0.4.4",
     "qunit-extras": "^2.1.0",
-    "qunitjs": "^2.0.0",
+    "qunitjs": "^2.0.1",
     "requirejs": "^2.2.0"
   },
   "files": [

--- a/plugin/ui.browserscope.js
+++ b/plugin/ui.browserscope.js
@@ -578,7 +578,7 @@
       setMessage(me.texts.loading);
       // request Browserscope chart data and pass it to `google.visualization.Query.setResponse()`
       (new visualization.Query(
-        '//www.browserscope.org/gviz_table_data?category=usertest_' + me.key + '&v=' + filterMap[filterBy],
+        'https://www.browserscope.org/gviz_table_data?category=usertest_' + me.key + '&v=' + filterMap[filterBy],
         { 'sendMethod': 'scriptInjection' }
       ))
       .send(onComplete);

--- a/plugin/ui.browserscope.js
+++ b/plugin/ui.browserscope.js
@@ -305,7 +305,7 @@
    */
   function createSnapshot() {
     // clone benches, exclude those that are errored, unrun, or have hz of Infinity
-    var benches = _.invoke(filter(ui.benchmarks, 'successful'), 'clone'),
+    var benches = _.invokeMap(filter(ui.benchmarks, 'successful'), 'clone'),
         fastest = filter(benches, 'fastest'),
         slowest = filter(benches, 'slowest');
 

--- a/plugin/ui.browserscope.js
+++ b/plugin/ui.browserscope.js
@@ -615,7 +615,7 @@
       // set "posting" message and attempt to post the results snapshot
       setMessage(me.texts.post);
 
-      // Note: We originally created an iframe to avoid Browerscope's old limit
+      // Note: We originally created an iframe to avoid Browserscope's old limit
       // of one beacon per page load. It's currently used to implement custom
       // request timeout and retry routines.
       var idoc = win.frames[name].document;
@@ -728,7 +728,7 @@
       !response && visualization && setMessage(me.texts.error);
       retry(true);
     }
-    // visualization chart gallary
+    // visualization chart gallery
     // https://developers.google.com/chart/interactive/docs/gallery
     else if (!ui.running) {
       var data = cloneData(response.getDataTable()),


### PR DESCRIPTION
(shown as `51% slower (✕ 2.0)`) as the computer is better at calculating both relative indicators than we are, and we can use our brain for the conclusions rather than the calculus.

(Of course one might want to see 'faster by a factor of X' instead, but this was more useful for my discussions.)

Don't know if you want this or want to keep the jsperf example as-is.

Anyway, thanks for all the work and the quick updates of the repo,

Cheers,
Ger
