### PR TITLE
Allow Asynchronous Calls in setup()/teardown() Functions

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -720,16 +720,46 @@
 
       if (bench.aborted) {
         // cycle() -> clone cycle/complete event -> compute()'s invoked bench.run() cycle/complete.
-        deferred.teardown();
-        clone.running = false;
-        cycle(deferred);
+        deferred.teardown(deferred);
       }
       else if (++deferred.cycles < clone.count) {
         clone.compiled.call(deferred, context, timer);
       }
       else {
         timer.stop(deferred);
-        deferred.teardown();
+        deferred.teardown(deferred);
+      }
+    }
+
+    /*------------------------------------------------------------------------*/
+
+    /**
+     * Handles completing the deferred setup function.
+     *
+     * @memberOf Benchmark.Deferred
+     */
+    function suResolve() {
+      // This is a placeholder function. The actual function is generated with
+      // each benchmark.
+    }
+
+    /*------------------------------------------------------------------------*/
+
+    /**
+     * Handles completing the deferred teardown function.
+     *
+     * @memberOf Benchmark.Deferred
+     */
+    function tdResolve() {
+      var deferred = this,
+          clone = deferred.benchmark,
+          bench = clone._original;
+
+      if (bench.aborted) {
+        clone.running = false;
+        cycle(deferred);
+      }
+      else {
         delay(clone, function() { cycle(deferred); });
       }
     }
@@ -1589,16 +1619,17 @@
             // When `deferred.cycles` is `0` then...
             'if(!d#.cycles){' +
             // set `deferred.fn`,
-            'd#.fn=function(){var ${fnArg}=d#;if(typeof f#=="function"){try{${fn}\n}catch(e#){f#(d#)}}else{${fn}\n}};' +
+            'd#.fn=function(){var ${fnArg}=d#;if(typeof f#=="function"){try{${fn}\n}catch(e#){f#(d#);}}else{${fn}\n}};' +
             // set `deferred.teardown`,
-            'd#.teardown=function(){d#.cycles=0;if(typeof td#=="function"){try{${teardown}\n}catch(e#){td#()}}else{${teardown}\n}};' +
-            // execute the benchmark's `setup`,
-            'if(typeof su#=="function"){try{${setup}\n}catch(e#){su#()}}else{${setup}\n};' +
-            // start timer,
-            't#.start(d#);' +
-            // and then execute `deferred.fn` and return a dummy object.
-            '}d#.fn();return{uid:"${uid}"}'
-
+            'd#.teardown=function(){d#.cycles=0;var ${fnArg}=d#;if(typeof td#=="function"){try{${teardown}\n}catch(e#){td#(d#);}}else{${teardown}\n}};' +
+            // generate setup resolve function
+            'd#.suResolve=function(){t#.start(d#);d#.fn();};' +
+            // execute the benchmark's `setup` with `deferred.suResolve` executing `deferred.fn`
+            'if(typeof su#=="function"){try{${setup}\n}catch(e#){su#(d#);}}else{${setup}\n}' +
+            // When `deferred.cycles` is not `0` then just execute `deferred.fn`
+            '}else{d#.fn();}' +
+            // and return a dummy object.
+            'return{uid:"${uid}"};'
           : 'var r#,s#,m#=this,f#=m#.fn,i#=m#.count,n#=t#.ns;${setup}\n${begin};' +
             'while(i#--){${fn}\n}${end};${teardown}\nreturn{elapsed:r#,uid:"${uid}"}';
 
@@ -2605,7 +2636,8 @@
     });
 
     _.assign(Deferred.prototype, {
-      'resolve': resolve
+      'resolve': resolve,
+      'tdResolve': tdResolve
     });
 
     /*------------------------------------------------------------------------*/

--- a/benchmark.js
+++ b/benchmark.js
@@ -1699,12 +1699,35 @@
 
         templateData.uid = uid + uidCounter++;
 
-        _.assign(templateData, {
-          'setup': decompilable ? getSource(bench.setup) : interpolate('m#.setup()'),
-          'fn': decompilable ? getSource(fn) : interpolate('m#.fn(' + fnArg + ')'),
-          'fnArg': fnArg,
-          'teardown': decompilable ? getSource(bench.teardown) : interpolate('m#.teardown()')
-        });
+        if (deferred) {
+          if (decompilable) {
+            var suSource = getSource(bench.setup),
+                tdSource = getSource(bench.teardown);
+
+            _.assign(templateData, {
+              'setup': (suSource == '' || suSource == '// No operation performed.') ? 'deferred.suResolve();' : getSource(bench.setup),
+              'fn': getSource(fn),
+              'fnArg': fnArg,
+              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? 'deferred.tdResolve();' : getSource(bench.teardown)
+            });
+          }
+          else {
+            _.assign(templateData, {
+              'setup': interpolate('d#.suResolve()'),
+              'fn': interpolate('m#.fn(' + fnArg + ')'),
+              'fnArg': fnArg,
+              'teardown': interpolate('d#.tdResolve()')
+            });
+          }
+        }
+        else {
+          _.assign(templateData, {
+            'setup': decompilable ? getSource(bench.setup) : interpolate('m#.setup()'),
+            'fn': decompilable ? getSource(fn) : interpolate('m#.fn(' + fnArg + ')'),
+            'fnArg': fnArg,
+            'teardown': decompilable ? getSource(bench.teardown) : interpolate('m#.teardown()')
+          });
+        }
 
         // Use API of chosen timer.
         if (timer.unit == 'ns') {

--- a/benchmark.js
+++ b/benchmark.js
@@ -1694,38 +1694,42 @@
        * Creates a compiled function from the given function `body`.
        */
       function createCompiled(bench, decompilable, deferred, body) {
-        var fn = bench.fn,
-            fnArg = deferred ? getFirstArgument(fn) || 'deferred' : '';
+        var setup = bench.setup,
+            fn = bench.fn,
+            teardown = bench.teardown,
+            suArg = deferred ? getFirstArgument(setup) : '',
+            fnArg = deferred ? getFirstArgument(fn) || 'deferred' : '',
+            tdArg = deferred ? getFirstArgument(teardown) : '';
 
         templateData.uid = uid + uidCounter++;
 
         if (deferred) {
           if (decompilable) {
-            var suSource = getSource(bench.setup),
-                tdSource = getSource(bench.teardown);
+            var suSource = getSource(setup),
+                tdSource = getSource(teardown);
 
             _.assign(templateData, {
-              'setup': (suSource == '' || suSource == '// No operation performed.') ? 'deferred.suResolve();' : getSource(bench.setup),
+              'setup': (suSource == '' || suSource == '// No operation performed.') ? 'deferred.suResolve();' : getSource(setup),
               'fn': getSource(fn),
               'fnArg': fnArg,
-              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? 'deferred.tdResolve();' : getSource(bench.teardown)
+              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? 'deferred.tdResolve();' : getSource(teardown)
             });
           }
           else {
             _.assign(templateData, {
-              'setup': interpolate('d#.suResolve()'),
-              'fn': interpolate('m#.fn(' + fnArg + ')'),
+              'setup': suArg ? interpolate('m#.setup(' + suArg + ');') : 'deferred.suResolve();',
+              'fn': interpolate('m#.fn(' + fnArg + ');'),
               'fnArg': fnArg,
-              'teardown': interpolate('d#.tdResolve()')
+              'teardown': tdArg ? interpolate('m#.teardown(' + tdArg + ');') : 'deferred.tdResolve();'
             });
           }
         }
         else {
           _.assign(templateData, {
-            'setup': decompilable ? getSource(bench.setup) : interpolate('m#.setup()'),
+            'setup': decompilable ? getSource(setup) : interpolate('m#.setup()'),
             'fn': decompilable ? getSource(fn) : interpolate('m#.fn(' + fnArg + ')'),
             'fnArg': fnArg,
-            'teardown': decompilable ? getSource(bench.teardown) : interpolate('m#.teardown()')
+            'teardown': decompilable ? getSource(teardown) : interpolate('m#.teardown()')
           });
         }
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -1709,18 +1709,18 @@
                 tdSource = getSource(teardown);
 
             _.assign(templateData, {
-              'setup': (suSource == '' || suSource == '// No operation performed.') ? 'deferred.suResolve();' : getSource(setup),
+              'setup': (suSource == '' || suSource == '// No operation performed.') ? interpolate('d#.suResolve();') : getSource(setup),
               'fn': getSource(fn),
               'fnArg': fnArg,
-              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? 'deferred.tdResolve();' : getSource(teardown)
+              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? interpolate('d#.tdResolve();') : getSource(teardown)
             });
           }
           else {
             _.assign(templateData, {
-              'setup': suArg ? interpolate('m#.setup(' + suArg + ');') : 'deferred.suResolve();',
+              'setup': suArg ? interpolate('m#.setup(' + suArg + ');') : interpolate('d#.suResolve();'),
               'fn': interpolate('m#.fn(' + fnArg + ');'),
               'fnArg': fnArg,
-              'teardown': tdArg ? interpolate('m#.teardown(' + tdArg + ');') : 'deferred.tdResolve();'
+              'teardown': tdArg ? interpolate('m#.teardown(' + tdArg + ');') : interpolate('d#.tdResolve();')
             });
           }
         }

--- a/test/test.js
+++ b/test/test.js
@@ -1234,9 +1234,9 @@
 
       Benchmark({
         'defer': true,
-        'setup': 'var x = [3, 2, 1];',
+        'setup': 'var x = [3, 2, 1]; setTimeout(function() { deferred.suResolve(); }, 10);',
         'fn': 'setTimeout(function() { x.sort(); deferred.resolve(); }, 10);',
-        'teardown': 'x.length = 0;',
+        'teardown': 'x.length = 0; setTimeout(function() { deferred.tdResolve(); }, 10);',
         'onComplete': function() {
           assert.ok(true);
           done();
@@ -1252,15 +1252,17 @@
 
       Benchmark({
         'defer': true,
-        'setup': function() {
+        'setup': function(deferred) {
           fired.push('setup');
+          setTimeout(function() { deferred.suResolve(); }, 10);
         },
         'fn': function(deferred) {
           fired.push('fn');
           setTimeout(function() { deferred.resolve(); }, 10);
         },
-        'teardown': function() {
+        'teardown': function(deferred) {
           fired.push('teardown');
+          setTimeout(function() { deferred.tdResolve(); }, 10);
         },
         'onComplete': function() {
           var actual = fired.join().replace(/(fn,)+/g, '$1').replace(/(setup,fn,teardown(?:,|$))+/, '$1');

--- a/test/test.js
+++ b/test/test.js
@@ -1229,6 +1229,23 @@
       .run();
     });
 
+    QUnit.test('should run a deferred benchmark correctly without being asynchronous', function(assert) {
+      var done = assert.async();
+
+      Benchmark(function(deferred) {
+        setTimeout(function() { deferred.resolve(); }, 1e3);
+      }, {
+        'defer': true,
+        'setup': function(deferred) { deferred.suResolve(); },
+        'teardown': function(deferred) { deferred.tdResolve(); },
+        'onComplete': function() {
+          assert.strictEqual(this.hz.toFixed(0), '1');
+          done();
+        }
+      })
+      .run();
+    });
+
     QUnit.test('should run with string values for "fn", "setup", and "teardown"', function(assert) {
       var done = assert.async();
 


### PR DESCRIPTION
This pull request is in reference to issue #70. To start off, this is a breaking change. When the `defer` option is set to true for a benchmark, both the `setup()` and `teardown()` functions require their resolve functions be called (`suResolve()` and `tdResolve()` respectively). If the functions are not included with the benchmark, the resolve calls are generated allowing `setup()` and `teardown()` functions to be omitted.

I tried to maintain the coding style as you describe, but have no problem changing variable names and such if you feel something else works better.

Currently, the unit tests are updated and are all passing when run with Node.js v4.x. I'm not very versed in running with the browser, so I'd appreciate any assistance people are willing to provide to test out these changes more. This includes verifying that the accuracy of the benchmarks has not been compromised.

Please reference the unit tests for examples of use. Documentation will need to be updated, but wanted to get some validation these changes will be accepted before investing the time to document.

Thanks for all the work you've put into benchmark.js.