### PR TITLE
chore: remove Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ env:
     - ISTANBUL=true
     - BIN=phantomjs
 
-matrix:
-  include:
-    - node_js: 4
-      env:
-
 git:
   depth: 10
 


### PR DESCRIPTION
Node.js 4 reached its EOL and the unit tests fail because most packages increased the minimum Node.js version to 6 (eg in npm).