### PR TITLE
feat: add endAtRME option to end when rme drops below threshold

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1834,6 +1834,7 @@
           elapsed = 0,
           initCount = bench.initCount,
           minSamples = bench.minSamples,
+          endAtRME = bench.endAtRME,
           queue = [],
           sample = bench.stats.sample;
 
@@ -1934,6 +1935,11 @@
             'sem': sem,
             'variance': variance
           });
+
+          // Exit early if we have reached a satisfying answer
+          if (size >= minSamples && rme < endAtRME) {
+            maxedOut = true;
+          }
 
           // Abort the cycle loop when the minimum sample size has been collected
           // and the elapsed time exceeds the maximum time allowed per benchmark.
@@ -2207,6 +2213,16 @@
          * @type number
          */
         'minTime': 0,
+
+        /**
+         * Exit the benchmark early if relative margin of error drops below
+         * this number. The benchmark will still adhere to the minSamples
+         * option.
+         *
+         * @memberOf Benchmark.options
+         * @type number
+         */
+        'endAtRME': 0,
 
         /**
          * The name of the benchmark.


### PR DESCRIPTION
This new config option allows to end the benchmark earlier than normal in case the relative margin of error drops below the specified amount, e.g. 1%.

Without this option, you'd have to set a high enough `maxTime` to ensure the benchmark ran long enough to get a low `rme`. With this option, the benchmark can exit as early as possible to save time.

Example

```js
const bench = new Benchmark('foo', fn, {
  endAtPct: 1 // end benchmark when rme is below 1%
})
```