### PR TITLE
docs: defer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ suite.add('RegExp#test', function() {
 .add('String#indexOf', function() {
   'Hello World!'.indexOf('o') > -1;
 })
+.add('String#indexOf#callback', function(deferred) {
+  setTimeout(() => {
+    'Hello World!'.indexOf('o') > -1;
+    deferred.resolve();
+  }, 1);
+}, { defer: true })
 // add listeners
 .on('cycle', function(event) {
   console.log(String(event.target));

--- a/benchmark.js
+++ b/benchmark.js
@@ -433,7 +433,7 @@
      * @constructor
      * @memberOf Benchmark
      * @param {string} name A name to identify the suite.
-     * @param {Object} [options={}] Options object.
+     * @param {Object} [options={}] Benchmark.options object.
      * @example
      *
      * // basic usage (the `new` operator is optional)


### PR DESCRIPTION
Fixes #55 

I was very confused about how to use `defer` reading docs only since I was using the `Suite` API but I thought that the input options should be [Suite options](https://benchmarkjs.com/docs#Suite_options) and not [Benchmark options](https://benchmarkjs.com/docs#options).

This PR would like to avoid this misunderstanding
