### PR TITLE
Fix Benchmark#toString() of error (again)

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1536,7 +1536,7 @@
         var errorStr;
         if (!_.isObject(error)) {
           errorStr = String(error);
-        } else if (!_.isError(Error)) {
+        } else if (!_.isError(error)) {
           errorStr = join(error);
         } else {
           // Error#name and Error#message properties are non-enumerable.


### PR DESCRIPTION
`Benchmark#toString()` incorrectly calls `join(error)` if `!_.isError(Error)`, which is always true because `Error` the function is not an instance of `Error`.  When `error` is an instance of `Error` this results in an empty string, as discussed in #122.

Fix the check to be `!_.isError(error)`.

I'm a bit confused about how this happened.  The issue appears to have occurred in b4bd1812, which was ostensibly authored by me.  However 9728173, which was the actually authored by me and merged in #122 does not have this error.  Perhaps a post-merge fix amended the commit and didn't change the author?

Thanks for considering,
Kevin